### PR TITLE
feat: Add GitHub MCP configuration

### DIFF
--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-github"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_GITHUB_TOKEN>"
+      }
+    }
+  }
+}

--- a/mcp.json
+++ b/mcp.json
@@ -1,13 +1,12 @@
 {
   "mcpServers": {
     "github": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-github"
-      ],
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_GITHUB_TOKEN>"
+      "transport": {
+        "type": "sse",
+        "url": "https://api.github.com/mcp/sse"
+      },
+      "headers": {
+        "Authorization": "Bearer <YOUR_GITHUB_TOKEN>"
       }
     }
   }


### PR DESCRIPTION
Add MCP config file with GitHub server setup to enable GitHub integration
through the Model Context Protocol. Users need to configure their GitHub
Personal Access Token to use this feature.