### PR TITLE
ci: PR checks (lint + build) and auto-merge setup

### DIFF
--- a/.github/rulesets/main-branch-protection.json
+++ b/.github/rulesets/main-branch-protection.json
@@ -1,0 +1,44 @@
+{
+  "name": "Protect main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "Lint", "integration_id": 15368 },
+          { "context": "Build", "integration_id": 15368 }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -29,8 +29,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm run build

--- a/docs/github-repo-settings.md
+++ b/docs/github-repo-settings.md
@@ -1,0 +1,65 @@
+# GitHub-Repo-Settings: PR-Checks & Auto-Merge
+
+**Datum:** 2026-07-06
+**Status:** Workflow aktiv, Settings müssen einmalig manuell gesetzt werden
+
+---
+
+## Ziel
+
+Jeder PR gegen `main` wird automatisch getestet (Lint + Build), und PRs können
+per Auto-Merge gemergt werden, sobald die Checks grün sind. Fehlerhafte PRs
+(z. B. von Renovate oder automatisierten Sessions) landen damit nicht mehr
+ungeprüft auf `main`.
+
+## Was bereits im Repo liegt
+
+| Datei | Zweck |
+| --- | --- |
+| `.github/workflows/ci.yml` | CI-Workflow: Jobs **Lint** (`npm run lint`) und **Build** (`npm run build`) laufen bei jedem PR und bei Pushes auf `main` |
+| `.github/rulesets/main-branch-protection.json` | Importierbares Ruleset, das die beiden Checks für `main` verpflichtend macht |
+| `renovate.json` | Renovate merged Minor/Patch/Pin/Digest-Updates automatisch, sobald die Checks grün sind |
+
+## Einmalige manuelle Schritte (GitHub-UI)
+
+Repo-Settings lassen sich nicht per Datei im Repo setzen — diese zwei Schritte
+müssen einmalig in der GitHub-Oberfläche gemacht werden:
+
+### 1. Auto-Merge erlauben
+
+**Settings → General → Pull Requests**
+
+- [x] **Allow auto-merge** aktivieren
+- Optional, aber empfohlen: **Automatically delete head branches** aktivieren
+
+### 2. Ruleset importieren
+
+**Settings → Rules → Rulesets → New ruleset ▾ → Import a ruleset**
+
+Datei `.github/rulesets/main-branch-protection.json` auswählen und speichern.
+
+Das Ruleset erzwingt für `main`:
+
+- **Pull Request Pflicht** — keine direkten Pushes auf `main` (0 Approvals
+  nötig, du kannst deine eigenen PRs also sofort mergen)
+- **Required Status Checks** — die Jobs `Lint` und `Build` müssen grün sein
+- **Kein Force-Push, kein Branch-Delete** auf `main`
+- **Bypass für Repository-Admins** — du selbst kannst im Notfall weiterhin
+  direkt auf `main` pushen; Bots (Renovate, GitHub Actions) können das nicht.
+  Wer den Bypass nicht will, entfernt im Ruleset den Eintrag unter
+  "Bypass list".
+
+## Wie Auto-Merge dann funktioniert
+
+- **Eigene PRs:** Im PR auf **Enable auto-merge** klicken. GitHub merged
+  automatisch, sobald Lint + Build grün sind.
+- **Renovate-PRs:** Renovate aktiviert Auto-Merge selbst für Minor-, Patch-,
+  Pin- und Digest-Updates (`renovate.json`). Major-Updates bleiben zur
+  manuellen Prüfung offen.
+
+## Wichtig bei Änderungen am Workflow
+
+Die Check-Namen im Ruleset (`Lint`, `Build`) müssen mit den Job-`name`-Feldern
+in `.github/workflows/ci.yml` übereinstimmen. Wer Jobs umbenennt oder ergänzt,
+muss das Ruleset unter **Settings → Rules → Rulesets** entsprechend anpassen —
+sonst warten PRs ewig auf einen Check, der nie kommt.

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,12 @@
 {
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "config:base"
+        "config:recommended"
+    ],
+    "packageRules": [
+        {
+            "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+            "automerge": true
+        }
     ]
 }


### PR DESCRIPTION
## Goal

The repo previously had no safeguards against faulty PRs. This PR ensures that every PR targeting `main` is automatically tested (lint + build) and that PRs can then be merged via auto-merge.

## Changes

- **`.github/workflows/ci.yml`** — New CI workflow with the jobs **Lint** (`npm run lint`, Biome) and **Build** (`npm run build`, Astro). Runs on every PR and on pushes to `main`. Node version comes from `.nvmrc`, npm cache enabled, superseded runs are cancelled. Both commands were verified locally and pass.
- **`.github/rulesets/main-branch-protection.json`** — Importable ruleset for `main`: PRs required (0 approvals), required status checks `Lint` + `Build`, no force-push/delete, bypass for repository admins.
- **`renovate.json`** — Auto-merge enabled for minor, patch, pin, and digest updates (Renovate uses GitHub's native auto-merge for this, so it only takes effect after the manual steps below). Major updates remain open for manual review. Also `config:base` → `config:recommended` (the old preset is deprecated).
- **`docs/github-repo-settings.md`** — Setup guide for the settings.

## ⚠️ One-time manual steps after merging

Repo settings cannot be configured via files — please do these once in the GitHub UI:

1. **Settings → General → Pull Requests**: enable "Allow auto-merge" (also recommended: "Automatically delete head branches")
2. **Settings → Rules → Rulesets → New ruleset ▾ → Import a ruleset**: import the file `.github/rulesets/main-branch-protection.json`

After that: click "Enable auto-merge" on your own PRs — GitHub merges as soon as Lint + Build are green. Renovate enables auto-merge for its own PRs automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgbQZwxqWGgbz99CtNUpaE