### PR TITLE
chore(renovate): keep PR branches and lockfile in sync with main

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,11 @@
     "extends": [
         "config:recommended"
     ],
+    "rebaseWhen": "behind-base-branch",
+    "lockFileMaintenance": {
+        "enabled": true,
+        "automerge": true
+    },
     "packageRules": [
         {
             "matchUpdateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
## Goal

Renovate PRs currently fail the new required CI checks because their branches (and thus `package-lock.json`) are stale relative to `main`, and in one case the lockfile could not be generated at all. This PR tunes the Renovate config so PR branches stay testable and auto-mergeable.

## Changes to `renovate.json`

- **`"rebaseWhen": "behind-base-branch"`** — Renovate now rebases every open PR branch as soon as it falls behind `main`, regenerating the lockfile against the current base. The old open PRs (#22–#31, created January–June) will be rebased and re-tested automatically instead of running CI against months-old state.
- **`"lockFileMaintenance": { "enabled": true, "automerge": true }`** — weekly refresh of transitive dependencies in `package-lock.json`, auto-merged once Lint + Build are green.

## Root cause of the linked failure (important!)

The failing check on #32 ([example run](https://github.com/stefanhoth/stefanhoth.github.io/actions/runs/28797892378/job/85393092038?pr=32)) is **not** a case of Renovate forgetting the lockfile — Renovate updates lockfiles by default. It's a peer-dependency deadlock between two PRs, which no config option can untangle:

- **#32** (security) bumps only `astro` `^5 → ^6`. Lockfile generation fails because `@astrojs/mdx@4.3.13` requires peer `astro@^5` (see the "⚠ Artifact update problem" comment on #32). Renovate opened the PR anyway because it's a vulnerability fix.
- **#28** (astro monorepo major) bumps `@astrojs/mdx` `^4 → ^7` and `@astrojs/react` `^4 → ^6` — but *not* `astro`, because the open security PR #32 already "owns" that update. Same conflict, mirrored.

**Recommended resolution:** upgrade astro to v6 together with `@astrojs/mdx` v7 and `@astrojs/react` v6 in one PR (happy to prepare that as a follow-up). Once that merges, Renovate closes #32 and #28 automatically and the CVE (GHSA-8hv8-536x-4wqp) is resolved. Merging #32 as-is would break `npm ci` on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgbQZwxqWGgbz99CtNUpaE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgbQZwxqWGgbz99CtNUpaE)_