### PR TITLE
chore: stop Renovate from scanning bundled skill templates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
     "extends": [
         "config:recommended"
     ],
+    "ignorePaths": [
+        ".agents/**"
+    ],
     "rebaseWhen": "behind-base-branch",
     "lockFileMaintenance": {
         "enabled": true,


### PR DESCRIPTION
## Summary
- Renovate was opening dependency-update PRs (#40–#43) against `.agents/skills/turnstile-spin/templates/worker/package.json` — a reference template bundled inside a Claude Code skill that's never installed or run in this repo
- Add `.agents/**` to `ignorePaths` so Renovate stops treating it as a real dependency manifest
- Closing #40–#43 as not applicable now that the root cause is fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)