### PR TITLE
feat: attach stefanhoth.com as a Custom Domain on the Worker

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,6 +4,7 @@
   "main": "./worker/index.js",
   "compatibility_date": "2026-07-06",
   "preview_urls": true,
+  "routes": [{ "pattern": "stefanhoth.com", "custom_domain": true }],
   "assets": {
     "directory": "./dist",
     "binding": "ASSETS"


### PR DESCRIPTION
## Summary
- Phase 2 of the Netlify → Cloudflare migration plan
- Add `stefanhoth.com` as a Custom Domain route on the `stefanhoth-com` Worker
- `www.stefanhoth.com` intentionally not added as its own route — the "www to root" Redirect Rule (configured in Phase 1.2) already fires at Cloudflare's edge before any origin lookup, so only the apex needs to reach the Worker

## Notes
- Inert until Phase 3 (Hetzner nameserver cutover) — Workers custom domains require the zone's nameservers to already be on Cloudflare
- `npm run build` verified locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)