### PR TITLE
fix: allow Turnstile script/frame in Content-Security-Policy

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -25,6 +25,8 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+        env:
+          PUBLIC_TURNSTILE_SITE_KEY: 0x4AAAAAADw4zdHIwQQk6qDu
       - name: Upload preview version
         id: deploy
         uses: cloudflare/wrangler-action@v4

--- a/public/_headers
+++ b/public/_headers
@@ -5,7 +5,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-src https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
 
 /_astro/*
   Cache-Control: public, max-age=31536000, immutable

--- a/worker/index.js
+++ b/worker/index.js
@@ -9,7 +9,7 @@ const SECURITY_HEADERS = {
     "geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()",
   "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
   "Content-Security-Policy":
-    "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
+    "default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-src https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
 };
 
 export default {


### PR DESCRIPTION
## Bugs found while debugging the contact form

### 1. CSP blocked the Turnstile script entirely
Confirmed via browser console on stefanhoth.com:
```
Content-Security-Policy: [...] blocked the loading of a resource on
https://challenges.cloudflare.com/turnstile/v0/api.js because it violates
the following directive: "script-src 'self' 'unsafe-inline'"
```
The CSP was carried over verbatim from the old `netlify.toml`, written before Turnstile existed.

**Fix:** add `https://challenges.cloudflare.com` to `script-src`, and a new `frame-src` directive, per [Cloudflare's documented Turnstile CSP requirements](https://developers.cloudflare.com/turnstile/). Fixed in both `worker/index.js` (Worker-routed responses) and `public/_headers` (literal asset matches served directly at Cloudflare's edge).

### 2. PUBLIC_TURNSTILE_SITE_KEY missing from every CI-built environment
`data-sitekey` was silently omitted from the rendered widget everywhere — production included:
```
curl -s https://stefanhoth.com/ | grep cf-turnstile
<div class="cf-turnstile" data-action="contact_form">   ← no data-sitekey at all
```
`PUBLIC_TURNSTILE_SITE_KEY` only ever existed in the local, gitignored `.env` — never configured in Cloudflare Workers Builds (production) or GitHub Actions (previews).

**Fix (this PR):** set it as a build-time env var in `preview-deploy.yml` for PR previews — safe to hardcode, it's the public sitekey, not the secret.
**Fix (separate, dashboard-only):** production needs the same variable added under Workers Build → Variables and secrets — the Workers Build config API is behind an account-level restriction I don't have access to, so this one has to be done manually.

### Also fixed directly on production (not part of this PR, no code change)
`TURNSTILE_SECRET_KEY` was never set on the deployed Worker (only existed in local `.dev.vars`) — set directly via the Workers secrets API since it's a secret value.

## Test plan
- [x] Verified locally via `wrangler dev`: CSP header now includes `challenges.cloudflare.com` on both `/` and a 404 response
- [ ] Real end-to-end submission on the PR preview URL, once the Turnstile widget's domain list includes `stefanhoth-de.workers.dev` (dashboard change, tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)