### PR TITLE
Fix contact form feedback + add test coverage

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,12 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "worker:dev", "--", "--port", "8789"],
       "port": 8789
+    },
+    {
+      "name": "astro-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 4321
     }
   ]
 }

--- a/.github/rulesets/main-branch-protection.json
+++ b/.github/rulesets/main-branch-protection.json
@@ -29,7 +29,9 @@
         "do_not_enforce_on_create": false,
         "required_status_checks": [
           { "context": "Lint", "integration_id": 15368 },
-          { "context": "Build", "integration_id": 15368 }
+          { "context": "Build", "integration_id": 15368 },
+          { "context": "Test", "integration_id": 15368 },
+          { "context": "E2E", "integration_id": 15368 }
         ]
       }
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,42 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm run test
+
+  e2e:
+    name: E2E
+    runs-on: ubuntu-latest
+    # Runs inside the official Playwright image (Chromium preinstalled) so CI
+    # doesn't download/install a browser on every run.
+    # Image tag must match @playwright/test's version in package.json.
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
+      options: --ipc=host
+    steps:
+      - uses: actions/checkout@v7
+      - name: Cache npm dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
+      - run: npm ci
+      - run: npm run test:e2e
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ dist/
 
 # Wrangler
 .wrangler/
+
+# Test artifacts
+test-results/
+playwright-report/
+blob-report/

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -50,6 +50,8 @@ npm run preview    # Preview production build
 npm run lint       # Run Biome linter
 npm run format     # Format code with Biome
 npm run lint:fix   # Auto-fix linting issues
+npm run test       # Run Vitest (unit + jsdom) tests
+npm run test:watch # Run Vitest in watch mode
 ```
 
 ## Key Features

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -52,6 +52,7 @@ npm run format     # Format code with Biome
 npm run lint:fix   # Auto-fix linting issues
 npm run test       # Run Vitest (unit + jsdom) tests
 npm run test:watch # Run Vitest in watch mode
+npm run test:e2e   # Run Playwright end-to-end tests (real browser)
 ```
 
 ## Key Features

--- a/docs/github-repo-settings.md
+++ b/docs/github-repo-settings.md
@@ -7,17 +7,17 @@
 
 ## Ziel
 
-Jeder PR gegen `main` wird automatisch getestet (Lint + Build), und PRs können
-per Auto-Merge gemergt werden, sobald die Checks grün sind. Fehlerhafte PRs
-(z. B. von Renovate oder automatisierten Sessions) landen damit nicht mehr
-ungeprüft auf `main`.
+Jeder PR gegen `main` wird automatisch getestet (Lint + Build + Test + E2E),
+und PRs können per Auto-Merge gemergt werden, sobald die Checks grün sind.
+Fehlerhafte PRs (z. B. von Renovate oder automatisierten Sessions) landen
+damit nicht mehr ungeprüft auf `main`.
 
 ## Was bereits im Repo liegt
 
 | Datei | Zweck |
 | --- | --- |
-| `.github/workflows/ci.yml` | CI-Workflow: Jobs **Lint** (`npm run lint`) und **Build** (`npm run build`) laufen bei jedem PR und bei Pushes auf `main` |
-| `.github/rulesets/main-branch-protection.json` | Importierbares Ruleset, das die beiden Checks für `main` verpflichtend macht |
+| `.github/workflows/ci.yml` | CI-Workflow: Jobs **Lint** (`npm run lint`), **Build** (`npm run build`), **Test** (`npm run test` — Vitest, unit + jsdom) und **E2E** (`npm run test:e2e` — Playwright im echten Browser) laufen bei jedem PR und bei Pushes auf `main` |
+| `.github/rulesets/main-branch-protection.json` | Importierbares Ruleset, das die vier Checks für `main` verpflichtend macht |
 | `renovate.json` | Renovate merged Minor/Patch/Pin/Digest-Updates automatisch, sobald die Checks grün sind |
 
 ## Einmalige manuelle Schritte (GitHub-UI)
@@ -42,7 +42,8 @@ Das Ruleset erzwingt für `main`:
 
 - **Pull Request Pflicht** — keine direkten Pushes auf `main` (0 Approvals
   nötig, du kannst deine eigenen PRs also sofort mergen)
-- **Required Status Checks** — die Jobs `Lint` und `Build` müssen grün sein
+- **Required Status Checks** — die Jobs `Lint`, `Build`, `Test` und `E2E`
+  müssen grün sein
 - **Kein Force-Push, kein Branch-Delete** auf `main`
 - **Bypass für Repository-Admins** — du selbst kannst im Notfall weiterhin
   direkt auf `main` pushen; Bots (Renovate, GitHub Actions) können das nicht.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,61 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.10",
+        "jsdom": "^29.1.1",
+        "vitest": "^4.1.10",
         "wrangler": "^4.107.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@astrojs/compiler-binding": {
       "version": "0.3.0",
@@ -768,6 +821,19 @@
         "node": ">=14.21.3"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@bruits/satteri-darwin-arm64": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.9.4.tgz",
@@ -1075,6 +1141,146 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1522,6 +1728,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@img/colour": {
@@ -2619,6 +2843,13 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
@@ -2927,6 +3158,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2935,6 +3177,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -3040,6 +3289,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -3121,6 +3483,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astring": {
@@ -3259,6 +3631,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
@@ -3333,6 +3715,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities": {
@@ -3578,6 +3970,20 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3594,6 +4000,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -3980,6 +4393,16 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4356,6 +4779,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -4497,6 +4933,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-wsl": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
@@ -4547,6 +4990,83 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/jsesc": {
@@ -6882,6 +7402,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/radix3": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
@@ -7162,6 +7692,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -7302,6 +7842,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -7399,6 +7952,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -7444,6 +8004,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -7515,6 +8089,13 @@
         "url": "https://opencollective.com/svgo"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
@@ -7550,6 +8131,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyclip": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.15.tgz",
@@ -7582,6 +8170,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.7.tgz",
+      "integrity": "sha512-56L0/9HELHSsG1bFCzay8UoLxzRL7kpFf7Wl5q/kSYwiSJGACvro61xnKzPNM+SadxllzdtXsKDSXE7HPeqIAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.7"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.7.tgz",
+      "integrity": "sha512-rNlAI8fKn/JckBMUSbNL/ES2kmDiurWaE49l+ikwEc9A6lFR7gMx9AhgQMQKBK4H5w4pKLH64JzZfB99uRsGNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -8097,6 +8741,109 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -8107,6 +8854,41 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which-pm-runs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
@@ -8114,6 +8896,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/workerd": {
@@ -8194,6 +8993,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.10",
+        "@playwright/test": "^1.61.1",
         "jsdom": "^29.1.1",
         "vitest": "^4.1.10",
         "wrangler": "^4.107.0"
@@ -2362,6 +2363,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -7344,6 +7361,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "worker:dev": "npm run build && wrangler dev",
     "worker:deploy": "npm run build && wrangler deploy",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@astrojs/mdx": "^7.0.0",
@@ -35,6 +36,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.10",
+    "@playwright/test": "^1.61.1",
     "jsdom": "^29.1.1",
     "vitest": "^4.1.10",
     "wrangler": "^4.107.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "format": "biome format --write .",
     "lint:fix": "biome check --write --unsafe .",
     "worker:dev": "npm run build && wrangler dev",
-    "worker:deploy": "npm run build && wrangler deploy"
+    "worker:deploy": "npm run build && wrangler deploy",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@astrojs/mdx": "^7.0.0",
@@ -33,6 +35,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.10",
+    "jsdom": "^29.1.1",
+    "vitest": "^4.1.10",
     "wrangler": "^4.107.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Cloudflare's public, documented Turnstile test sitekey that always passes
+// invisibly. Not a secret — see https://developers.cloudflare.com/turnstile/troubleshooting/testing/
+const TURNSTILE_TEST_SITEKEY = "1x00000000000000000000BB";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  reporter: "list",
+  use: {
+    baseURL: "http://localhost:4322",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    // `astro dev` daemonizes itself by default (Astro 7), which confuses
+    // Playwright's process supervision — build + preview instead, which
+    // runs as a plain foreground server.
+    command: "npm run build && npm run preview -- --port 4322",
+    url: "http://localhost:4322",
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+    env: {
+      PUBLIC_TURNSTILE_SITE_KEY: TURNSTILE_TEST_SITEKEY,
+    },
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,22 @@
         {
             "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
             "automerge": true
+        },
+        {
+            "description": "Group @playwright/test and the MCR container image tag — they must stay in sync",
+            "matchPackageNames": ["@playwright/test"],
+            "groupName": "Playwright"
+        }
+    ],
+    "customManagers": [
+        {
+            "customType": "regex",
+            "managerFilePatterns": ["/^\\.github/workflows/.*\\.yml$/"],
+            "matchStrings": [
+                "image: mcr\\.microsoft\\.com/playwright:v(?<currentValue>[^-]+)-noble"
+            ],
+            "depNameTemplate": "@playwright/test",
+            "datasourceTemplate": "npm"
         }
     ]
 }

--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -1,8 +1,10 @@
 ---
 // Contact form component — posts to the Cloudflare Pages Function at /contact
+const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
 ---
 
 <form name="contact" id="contact" method="POST" action="/contact">
+  <p id="contact-status" class="contact-status" role="status" aria-live="polite" hidden></p>
   <input
     type="text"
     class="form-control"
@@ -31,11 +33,29 @@
     data-validation-required-message="Please enter a message."></textarea>
   <div
     class="cf-turnstile"
-    data-sitekey={import.meta.env.PUBLIC_TURNSTILE_SITE_KEY}
+    data-sitekey={turnstileSiteKey}
     data-action="contact_form"
+    data-callback="onTurnstileSuccess"
+    data-error-callback="onTurnstileError"
+    data-expired-callback="onTurnstileExpired"
   >
   </div>
+  <noscript>
+    <p class="contact-status contact-status--error">
+      JavaScript is required for bot verification. Please enable JavaScript, or email me directly
+      instead.
+    </p>
+  </noscript>
   <button type="submit">Let's go!</button>
 </form>
 
 <script is:inline src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+
+<script>
+  import { initContactForm } from "../lib/contactForm.js";
+
+  initContactForm({
+    form: document.getElementById("contact"),
+    statusEl: document.getElementById("contact-status"),
+  });
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -326,6 +326,38 @@ const {
         box-shadow: var(--shadow);
       }
 
+      .contact-status {
+        padding: 1rem 1.25rem;
+        border-radius: 8px;
+        margin-bottom: 1rem;
+        font-weight: 600;
+        border: 1px solid transparent;
+      }
+
+      .contact-status--success {
+        background: #ecfdf5;
+        border-color: #10b981;
+        color: #065f46;
+      }
+
+      .contact-status--error {
+        background: #fef2f2;
+        border-color: #ef4444;
+        color: #991b1b;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .contact-status--success {
+          background: rgba(16, 185, 129, 0.15);
+          color: #6ee7b7;
+        }
+
+        .contact-status--error {
+          background: rgba(239, 68, 68, 0.15);
+          color: #fca5a5;
+        }
+      }
+
       input,
       textarea {
         width: 100%;
@@ -360,6 +392,17 @@ const {
 
       button:hover {
         background: #0b5ed7;
+      }
+
+      button:disabled {
+        background: var(--border);
+        color: var(--text);
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+
+      button:disabled:hover {
+        background: var(--border);
       }
 
       .hidden {

--- a/src/lib/contactForm.js
+++ b/src/lib/contactForm.js
@@ -1,0 +1,102 @@
+// Pure helpers + DOM wiring for the contact form's client-side status handling.
+// Extracted from ContactForm.astro so the logic can be unit/jsdom tested directly.
+
+export const STATUS_MESSAGES = {
+  sent: {
+    type: "success",
+    text: "Thanks for your message! I'll get back to you as soon as possible.",
+  },
+  error: {
+    type: "error",
+    text: "Something went wrong while sending. Please try again, or email me directly instead.",
+  },
+};
+
+export function getStatusKeyFromSearch(search) {
+  const params = new URLSearchParams(search);
+  if (params.has("sent")) return "sent";
+  if (params.has("error")) return "error";
+  return null;
+}
+
+export function buildUrlWithoutStatusParams(pathname, search, hash) {
+  const params = new URLSearchParams(search);
+  params.delete("sent");
+  params.delete("error");
+  const query = params.toString();
+  return `${pathname}${query ? `?${query}` : ""}${hash}`;
+}
+
+export function initContactForm({ form, statusEl, win = window, turnstileLoadTimeoutMs = 8000 }) {
+  const submitButton = form?.querySelector('button[type="submit"]');
+  const turnstileWidget = form?.querySelector(".cf-turnstile");
+  let turnstileIssueActive = false;
+
+  function showStatus(type, text) {
+    if (!statusEl) return;
+    statusEl.textContent = text;
+    statusEl.hidden = false;
+    statusEl.className = `contact-status contact-status--${type}`;
+  }
+
+  function showStatusFromLocation() {
+    const key = getStatusKeyFromSearch(win.location.search);
+    if (!key) return;
+
+    showStatus(STATUS_MESSAGES[key].type, STATUS_MESSAGES[key].text);
+    statusEl?.scrollIntoView?.({ behavior: "smooth", block: "center" });
+
+    const cleanedUrl = buildUrlWithoutStatusParams(
+      win.location.pathname,
+      win.location.search,
+      win.location.hash,
+    );
+    win.history.replaceState({}, "", cleanedUrl);
+  }
+
+  function disableSubmit(reasonText) {
+    turnstileIssueActive = true;
+    showStatus("error", reasonText);
+    submitButton?.setAttribute("disabled", "true");
+  }
+
+  function handleTurnstileSuccess() {
+    submitButton?.removeAttribute("disabled");
+    if (turnstileIssueActive) {
+      turnstileIssueActive = false;
+      if (statusEl) statusEl.hidden = true;
+    }
+  }
+
+  function handleTurnstileError() {
+    disableSubmit(
+      "Bot protection failed to load. Please reload the page, or email me directly instead.",
+    );
+  }
+
+  function handleTurnstileExpired() {
+    disableSubmit("Bot verification expired. Please reload the page.");
+  }
+
+  if (form) {
+    if (!turnstileWidget?.getAttribute("data-sitekey")) {
+      disableSubmit(
+        "This contact form isn't fully set up right now (bot protection is missing). Please email me directly instead.",
+      );
+    } else {
+      win.onTurnstileSuccess = handleTurnstileSuccess;
+      win.onTurnstileError = handleTurnstileError;
+      win.onTurnstileExpired = handleTurnstileExpired;
+
+      win.setTimeout(() => {
+        if (!win.turnstile) {
+          handleTurnstileError();
+        }
+      }, turnstileLoadTimeoutMs);
+    }
+  }
+
+  showStatusFromLocation();
+
+  return { showStatus, handleTurnstileSuccess, handleTurnstileError, handleTurnstileExpired };
+}

--- a/tests/dom/contactForm.dom.test.js
+++ b/tests/dom/contactForm.dom.test.js
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import { initContactForm } from "../../src/lib/contactForm.js";
+
+function renderForm({ sitekey = "test-sitekey" } = {}) {
+  document.body.innerHTML = `
+    <form id="contact">
+      <p id="contact-status" hidden></p>
+      <div class="cf-turnstile" ${sitekey ? `data-sitekey="${sitekey}"` : ""}></div>
+      <button type="submit">Let's go!</button>
+    </form>
+  `;
+  return {
+    form: document.getElementById("contact"),
+    statusEl: document.getElementById("contact-status"),
+    button: document.querySelector('#contact button[type="submit"]'),
+  };
+}
+
+describe("initContactForm", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("disables the submit button and warns when the Turnstile sitekey is missing", () => {
+    const { form, statusEl, button } = renderForm({ sitekey: "" });
+
+    initContactForm({ form, statusEl, win: window });
+
+    expect(button.disabled).toBe(true);
+    expect(statusEl.hidden).toBe(false);
+    expect(statusEl.className).toContain("contact-status--error");
+    expect(statusEl.textContent).toMatch(/isn't fully set up/i);
+  });
+
+  it("leaves the submit button enabled when the sitekey is present", () => {
+    const { form, statusEl, button } = renderForm();
+
+    initContactForm({ form, statusEl, win: window });
+
+    expect(button.disabled).toBe(false);
+    expect(statusEl.hidden).toBe(true);
+  });
+
+  it("shows the success banner and cleans the URL for ?sent=true", () => {
+    const { form, statusEl } = renderForm();
+    const fakeWindow = {
+      location: { pathname: "/", search: "?sent=true", hash: "" },
+      history: { replaceState: (_state, _title, url) => { fakeWindow.location.search = new URL(url, "https://example.com").search; } },
+      setTimeout: () => {},
+      turnstile: {},
+    };
+
+    initContactForm({ form, statusEl, win: fakeWindow });
+
+    expect(statusEl.hidden).toBe(false);
+    expect(statusEl.className).toContain("contact-status--success");
+    expect(statusEl.textContent).toMatch(/thanks for your message/i);
+    expect(fakeWindow.location.search).toBe("");
+  });
+
+  it("disables submit and shows an error when the Turnstile error callback fires", () => {
+    const { form, statusEl, button } = renderForm();
+
+    initContactForm({ form, statusEl, win: window });
+    window.onTurnstileError();
+
+    expect(button.disabled).toBe(true);
+    expect(statusEl.hidden).toBe(false);
+    expect(statusEl.className).toContain("contact-status--error");
+  });
+
+  it("re-enables submit on a later Turnstile success after an error", () => {
+    const { form, statusEl, button } = renderForm();
+
+    initContactForm({ form, statusEl, win: window });
+    window.onTurnstileError();
+    window.onTurnstileSuccess();
+
+    expect(button.disabled).toBe(false);
+    expect(statusEl.hidden).toBe(true);
+  });
+
+  it("does not clear a real ?error=true submission banner when Turnstile later succeeds", () => {
+    // Regression test: onTurnstileSuccess must only clear *its own* warning,
+    // not an unrelated status banner rendered from the redirect query params.
+    const { form, statusEl } = renderForm();
+    const fakeWindow = {
+      location: { pathname: "/", search: "?error=true", hash: "" },
+      history: { replaceState: () => {} },
+      setTimeout: () => {},
+      turnstile: {},
+    };
+
+    initContactForm({ form, statusEl, win: fakeWindow });
+    fakeWindow.onTurnstileSuccess();
+
+    expect(statusEl.hidden).toBe(false);
+    expect(statusEl.textContent).toMatch(/something went wrong/i);
+  });
+
+  it("falls back to an error state if the Turnstile script never loads", () => {
+    const { form, statusEl, button } = renderForm();
+    let timeoutCallback;
+    const fakeWindow = {
+      location: { pathname: "/", search: "", hash: "" },
+      history: { replaceState: () => {} },
+      setTimeout: (cb) => {
+        timeoutCallback = cb;
+      },
+      turnstile: undefined,
+    };
+
+    initContactForm({ form, statusEl, win: fakeWindow, turnstileLoadTimeoutMs: 8000 });
+    expect(button.disabled).toBe(false);
+
+    timeoutCallback();
+
+    expect(button.disabled).toBe(true);
+    expect(statusEl.textContent).toMatch(/bot protection failed to load/i);
+  });
+});

--- a/tests/e2e/contact-form.spec.ts
+++ b/tests/e2e/contact-form.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+
+test("renders the form with a working Turnstile widget and enabled submit button", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  // The test sitekey resolves invisibly (no iframe) but populates the hidden
+  // response token once solved — that's what proves the widget actually ran.
+  const tokenInput = page.locator('input[name="cf-turnstile-response"]');
+  await expect(tokenInput).toHaveValue(/\S+/, { timeout: 10_000 });
+  await expect(page.locator('#contact button[type="submit"]')).toBeEnabled();
+  await expect(page.locator("#contact-status")).toBeHidden();
+});
+
+test("shows a success banner and cleans the URL for ?sent=true", async ({ page }) => {
+  await page.goto("/?sent=true");
+
+  const status = page.locator("#contact-status");
+  await expect(status).toBeVisible();
+  await expect(status).toContainText("Thanks for your message");
+  await expect(page).toHaveURL(/\/$/);
+});
+
+test("shows an error banner and cleans the URL for ?error=true", async ({ page }) => {
+  await page.goto("/?error=true");
+
+  const status = page.locator("#contact-status");
+  await expect(status).toBeVisible();
+  await expect(status).toContainText("Something went wrong");
+  await expect(page).toHaveURL(/\/$/);
+});
+
+test("disables submit and warns when the Turnstile script fails to load", async ({ page }) => {
+  await page.route("**/challenges.cloudflare.com/turnstile/v0/api.js", (route) => route.abort());
+
+  await page.goto("/");
+
+  const status = page.locator("#contact-status");
+  await expect(status).toBeVisible({ timeout: 10_000 });
+  await expect(status).toContainText("Bot protection failed to load");
+  await expect(page.locator('#contact button[type="submit"]')).toBeDisabled();
+});

--- a/tests/unit/contact-handler.test.js
+++ b/tests/unit/contact-handler.test.js
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendMailViaSmtp = vi.fn();
+
+vi.mock("../../functions/smtp.js", () => ({
+  sendMailViaSmtp: (...args) => sendMailViaSmtp(...args),
+}));
+
+const { onRequestPost } = await import("../../functions/contact.js");
+
+function buildEnv() {
+  return {
+    TURNSTILE_SECRET_KEY: "test-secret",
+    MAILSENDER_SMTP_USER: "user@example.com",
+    MAILSENDER_SMTP_PASS: "password",
+  };
+}
+
+function buildRequest(overrides = {}) {
+  const fields = {
+    "cf-turnstile-response": "test-token",
+    name: "Jane Doe",
+    email: "jane@example.com",
+    message: "Hello there",
+    ...overrides,
+  };
+  const formData = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== undefined) formData.set(key, value);
+  }
+  return new Request("https://example.com/contact", { method: "POST", body: formData });
+}
+
+function mockTurnstileVerify(success) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({ json: async () => ({ success }) }),
+  );
+}
+
+describe("onRequestPost", () => {
+  beforeEach(() => {
+    sendMailViaSmtp.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("redirects to /?error=true when Turnstile verification fails", async () => {
+    mockTurnstileVerify(false);
+
+    const response = await onRequestPost({ request: buildRequest(), env: buildEnv() });
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("https://example.com/?error=true");
+    expect(sendMailViaSmtp).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /?error=true when a required field is missing", async () => {
+    mockTurnstileVerify(true);
+
+    const response = await onRequestPost({
+      request: buildRequest({ message: "" }),
+      env: buildEnv(),
+    });
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("https://example.com/?error=true");
+    expect(sendMailViaSmtp).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /?error=true when sending the email fails", async () => {
+    mockTurnstileVerify(true);
+    sendMailViaSmtp.mockRejectedValue(new Error("SMTP down"));
+
+    const response = await onRequestPost({ request: buildRequest(), env: buildEnv() });
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("https://example.com/?error=true");
+  });
+
+  it("escapes the message in the HTML body and redirects to /?sent=true on success", async () => {
+    mockTurnstileVerify(true);
+    sendMailViaSmtp.mockResolvedValue(undefined);
+
+    const response = await onRequestPost({
+      request: buildRequest({ message: "Hi <script>alert(1)</script>" }),
+      env: buildEnv(),
+    });
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("https://example.com/?sent=true");
+
+    expect(sendMailViaSmtp).toHaveBeenCalledTimes(1);
+    const mailArgs = sendMailViaSmtp.mock.calls[0][0];
+    expect(mailArgs.to).toBe("website-form@stefanhoth.de");
+    expect(mailArgs.replyTo).toBe("jane@example.com");
+    expect(mailArgs.text).toContain("Hi <script>alert(1)</script>");
+    expect(mailArgs.html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(mailArgs.html).not.toContain("<script>alert(1)</script>");
+  });
+});

--- a/tests/unit/contactForm.test.js
+++ b/tests/unit/contactForm.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { buildUrlWithoutStatusParams, getStatusKeyFromSearch } from "../../src/lib/contactForm.js";
+
+describe("getStatusKeyFromSearch", () => {
+  it("returns null when there is no status param", () => {
+    expect(getStatusKeyFromSearch("")).toBeNull();
+    expect(getStatusKeyFromSearch("?foo=bar")).toBeNull();
+  });
+
+  it("detects sent", () => {
+    expect(getStatusKeyFromSearch("?sent=true")).toBe("sent");
+  });
+
+  it("detects error", () => {
+    expect(getStatusKeyFromSearch("?error=true")).toBe("error");
+  });
+
+  it("prefers sent when both are somehow present", () => {
+    expect(getStatusKeyFromSearch("?sent=true&error=true")).toBe("sent");
+  });
+});
+
+describe("buildUrlWithoutStatusParams", () => {
+  it("strips sent/error but keeps other params, path and hash", () => {
+    const url = buildUrlWithoutStatusParams("/", "?sent=true&ref=newsletter", "#contact");
+    expect(url).toBe("/?ref=newsletter#contact");
+  });
+
+  it("returns a clean path when no other params remain", () => {
+    const url = buildUrlWithoutStatusParams("/", "?error=true", "");
+    expect(url).toBe("/");
+  });
+
+  it("is a no-op when there is nothing to strip", () => {
+    const url = buildUrlWithoutStatusParams("/", "", "");
+    expect(url).toBe("/");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/unit/**/*.test.js", "tests/dom/**/*.test.js"],
+  },
+});


### PR DESCRIPTION
## Summary
- The contact form gave no feedback about Turnstile misconfiguration/load failures, and a redirect to `/?sent=true` or `/?error=true` rendered nothing different on the page. Both now show an inline status banner (and the submit button is disabled with an explanation when Turnstile can't be verified).
- Added Vitest unit + jsdom tests and Playwright e2e tests (real Chromium, Cloudflare's public test sitekey) for the new behavior.
- Wired both into CI: new `Test`/`E2E` jobs (E2E runs inside the official Playwright container image, no per-run Chromium download), added as required checks in the branch-protection ruleset, and Renovate keeps the container image tag in sync with the `@playwright/test` npm version.

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (18 Vitest unit + jsdom tests)
- [x] `npm run test:e2e` (4 Playwright tests, real Chromium)
- [x] `npm run build`
- [x] Re-import `.github/rulesets/main-branch-protection.json` in Settings → Rules → Rulesets so the new `Test`/`E2E` checks are actually enforced (GitHub doesn't auto-sync ruleset files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)