### PR TITLE
fix: reject CRLF in contact form name/email (SMTP header injection)

### DIFF
--- a/functions/contact.js
+++ b/functions/contact.js
@@ -13,6 +13,12 @@ function escapeHtml(str) {
   );
 }
 
+// Values placed in email headers (Subject, Reply-To) must not contain CR/LF,
+// or a submitter could inject arbitrary extra SMTP/MIME header lines.
+function containsHeaderInjection(value) {
+  return /[\r\n]/.test(value);
+}
+
 export async function onRequestPost(context) {
   const { request, env } = context;
   const origin = new URL(request.url).origin;
@@ -36,7 +42,14 @@ export async function onRequestPost(context) {
   const website = formData.get("website")?.toString().trim();
   const message = formData.get("message")?.toString().trim();
 
-  if (!turnstileOk || !name || !email || !message) {
+  if (
+    !turnstileOk ||
+    !name ||
+    !email ||
+    !message ||
+    containsHeaderInjection(name) ||
+    containsHeaderInjection(email)
+  ) {
     return Response.redirect(`${origin}/?error=true`, 303);
   }
 

--- a/tests/unit/contact-handler.test.js
+++ b/tests/unit/contact-handler.test.js
@@ -80,6 +80,32 @@ describe("onRequestPost", () => {
     expect(response.headers.get("location")).toBe("https://example.com/?error=true");
   });
 
+  it("redirects to /?error=true when name contains a CRLF (header injection attempt)", async () => {
+    mockTurnstileVerify(true);
+
+    const response = await onRequestPost({
+      request: buildRequest({ name: "Bob\r\nBcc: attacker@example.com" }),
+      env: buildEnv(),
+    });
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("https://example.com/?error=true");
+    expect(sendMailViaSmtp).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /?error=true when email contains a CRLF (header injection attempt)", async () => {
+    mockTurnstileVerify(true);
+
+    const response = await onRequestPost({
+      request: buildRequest({ email: "jane@example.com\r\nBcc: attacker@example.com" }),
+      env: buildEnv(),
+    });
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("https://example.com/?error=true");
+    expect(sendMailViaSmtp).not.toHaveBeenCalled();
+  });
+
   it("escapes the message in the HTML body and redirects to /?sent=true on success", async () => {
     mockTurnstileVerify(true);
     sendMailViaSmtp.mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary
- `name` is interpolated into the email `Subject` header and `email` into `Reply-To`, both unsanitized beyond `.trim()`
- A submitter could include CR/LF in either field to inject arbitrary extra SMTP/MIME headers (e.g. `Bcc:`) into the outgoing message
- Now rejects (redirects to `/?error=true`) any submission where `name` or `email` contains `\r` or `\n`

## Test plan
- [x] Added two regression tests in `tests/unit/contact-handler.test.js` covering CRLF injection attempts via `name` and `email`
- [x] `npx vitest run` — 20/20 passing
- [x] `biome lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)