### PR TITLE
security: harden contact form handler, CSP, and Worker responses

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,5 +12,10 @@ export default defineConfig({
 
   vite: {
     plugins: [tailwindcss()],
+    build: {
+      // Never inline scripts into the HTML — the Worker's CSP has no
+      // 'unsafe-inline' in script-src, so all scripts must be external files.
+      assetsInlineLimit: 0,
+    },
   },
 });

--- a/functions/contact.js
+++ b/functions/contact.js
@@ -19,22 +19,50 @@ function containsHeaderInjection(value) {
   return /[\r\n]/.test(value);
 }
 
+// Server-side size limits (the client-side maxlength attributes mirror these).
+const MAX_LENGTHS = {
+  name: 200,
+  email: 320,
+  phone: 100,
+  website: 500,
+  message: 5000,
+};
+
+function exceedsMaxLength(fields) {
+  return Object.entries(MAX_LENGTHS).some(
+    ([field, max]) => (fields[field]?.length ?? 0) > max,
+  );
+}
+
 export async function onRequestPost(context) {
   const { request, env } = context;
   const origin = new URL(request.url).origin;
-  const formData = await request.formData();
+
+  let formData;
+  try {
+    formData = await request.formData();
+  } catch {
+    // Not a form submission (wrong content type / malformed body).
+    return Response.redirect(`${origin}/?error=true`, 303);
+  }
 
   const token = formData.get("cf-turnstile-response");
-  const verifyResponse = await fetch(TURNSTILE_VERIFY_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      secret: env.TURNSTILE_SECRET_KEY,
-      response: token,
-      remoteip: request.headers.get("CF-Connecting-IP"),
-    }),
-  });
-  const { success: turnstileOk } = await verifyResponse.json();
+  let turnstileOk = false;
+  try {
+    const verifyResponse = await fetch(TURNSTILE_VERIFY_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        secret: env.TURNSTILE_SECRET_KEY,
+        response: token,
+        remoteip: request.headers.get("CF-Connecting-IP"),
+      }),
+    });
+    ({ success: turnstileOk } = await verifyResponse.json());
+  } catch (err) {
+    // Treat a siteverify outage as verification failure (fail closed).
+    console.error("Turnstile verification failed", err);
+  }
 
   const name = formData.get("name")?.toString().trim();
   const email = formData.get("email")?.toString().trim();
@@ -48,7 +76,8 @@ export async function onRequestPost(context) {
     !email ||
     !message ||
     containsHeaderInjection(name) ||
-    containsHeaderInjection(email)
+    containsHeaderInjection(email) ||
+    exceedsMaxLength({ name, email, phone, website, message })
   ) {
     return Response.redirect(`${origin}/?error=true`, 303);
   }

--- a/functions/smtp.js
+++ b/functions/smtp.js
@@ -72,7 +72,9 @@ export async function sendMailViaSmtp({ host, port, username, password, from, to
     const authToken = btoa(`\0${username}\0${password}`);
     assertCode(await sendCommand(writer, reader, `AUTH PLAIN ${authToken}`), [235], "AUTH");
 
-    assertCode(await sendCommand(writer, reader, `MAIL FROM:<${from}>`), [250], "MAIL FROM");
+    // The envelope takes a bare address — `from` may be `"Display Name" <addr>`.
+    const envelopeFrom = from.match(/<([^>]+)>/)?.[1] ?? from;
+    assertCode(await sendCommand(writer, reader, `MAIL FROM:<${envelopeFrom}>`), [250], "MAIL FROM");
     assertCode(await sendCommand(writer, reader, `RCPT TO:<${to}>`), [250], "RCPT TO");
     assertCode(await sendCommand(writer, reader, "DATA"), [354], "DATA");
 

--- a/public/_headers
+++ b/public/_headers
@@ -1,11 +1,11 @@
 /*
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
-  X-XSS-Protection: 1; mode=block
+  X-XSS-Protection: 0
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-src https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-src https://challenges.cloudflare.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'
 
 /_astro/*
   Cache-Control: public, max-age=31536000, immutable

--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -12,6 +12,7 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
     id="name"
     name="name"
     required
+    maxlength="200"
     data-validation-required-message="Please enter your name."
   />
   <input
@@ -20,16 +21,18 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
     id="email"
     name="email"
     required
+    maxlength="320"
     data-validation-required-message="Please enter your email address."
   />
-  <input type="tel" placeholder="Your phone number" id="phone" name="phone" />
-  <input type="url" placeholder="Your website" id="website" name="website" />
+  <input type="tel" placeholder="Your phone number" id="phone" name="phone" maxlength="100" />
+  <input type="url" placeholder="Your website" id="website" name="website" maxlength="500" />
   <textarea
     rows="5"
     placeholder="Dear Stefan..."
     id="message"
     name="message"
     required
+    maxlength="5000"
     data-validation-required-message="Please enter a message."></textarea>
   <div
     class="cf-turnstile"

--- a/tests/unit/contact-handler.test.js
+++ b/tests/unit/contact-handler.test.js
@@ -106,6 +106,57 @@ describe("onRequestPost", () => {
     expect(sendMailViaSmtp).not.toHaveBeenCalled();
   });
 
+  it("redirects to /?error=true when a field exceeds its maximum length", async () => {
+    mockTurnstileVerify(true);
+
+    const response = await onRequestPost({
+      request: buildRequest({ message: "x".repeat(5001) }),
+      env: buildEnv(),
+    });
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("https://example.com/?error=true");
+    expect(sendMailViaSmtp).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /?error=true when the name exceeds its maximum length", async () => {
+    mockTurnstileVerify(true);
+
+    const response = await onRequestPost({
+      request: buildRequest({ name: "x".repeat(201) }),
+      env: buildEnv(),
+    });
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("https://example.com/?error=true");
+    expect(sendMailViaSmtp).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /?error=true when the body is not form data", async () => {
+    mockTurnstileVerify(true);
+
+    const request = new Request("https://example.com/contact", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Jane" }),
+    });
+    const response = await onRequestPost({ request, env: buildEnv() });
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("https://example.com/?error=true");
+    expect(sendMailViaSmtp).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /?error=true when the Turnstile siteverify call throws (fails closed)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("siteverify down")));
+
+    const response = await onRequestPost({ request: buildRequest(), env: buildEnv() });
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("https://example.com/?error=true");
+    expect(sendMailViaSmtp).not.toHaveBeenCalled();
+  });
+
   it("escapes the message in the HTML body and redirects to /?sent=true on success", async () => {
     mockTurnstileVerify(true);
     sendMailViaSmtp.mockResolvedValue(undefined);

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,34 +1,46 @@
 import { onRequestPost } from "../functions/contact.js";
 
+// Requests that match a static asset are served by Cloudflare's asset layer
+// without invoking this Worker — those get their headers from public/_headers.
+// Keep the two header sets in sync. This set covers Worker-handled responses
+// (POST /contact) and any request that falls through to the Worker.
 const SECURITY_HEADERS = {
   "X-Frame-Options": "DENY",
   "X-Content-Type-Options": "nosniff",
-  "X-XSS-Protection": "1; mode=block",
+  // "0" disables the legacy XSS auditor, which is deprecated and can itself
+  // be abused for cross-site leaks in older browsers. CSP is the real defense.
+  "X-XSS-Protection": "0",
   "Referrer-Policy": "strict-origin-when-cross-origin",
   "Permissions-Policy":
     "geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()",
   "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+  // script-src has no 'unsafe-inline': Astro is configured (assetsInlineLimit: 0)
+  // to emit all scripts as external files. style-src keeps 'unsafe-inline' for
+  // Astro's inlined stylesheets and the Turnstile widget's style attributes.
   "Content-Security-Policy":
-    "default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-src https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
+    "default-src 'self'; script-src 'self' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-src https://challenges.cloudflare.com; frame-ancestors 'none'; object-src 'none'; base-uri 'self'; form-action 'self'",
 };
+
+function withSecurityHeaders(response) {
+  const headers = new Headers(response.headers);
+  for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
+    headers.set(name, value);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
 
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
 
     if (request.method === "POST" && url.pathname === "/contact") {
-      return onRequestPost({ request, env });
+      return withSecurityHeaders(await onRequestPost({ request, env }));
     }
 
-    const response = await env.ASSETS.fetch(request);
-    const headers = new Headers(response.headers);
-    for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
-      headers.set(name, value);
-    }
-    return new Response(response.body, {
-      status: response.status,
-      statusText: response.statusText,
-      headers,
-    });
+    return withSecurityHeaders(await env.ASSETS.fetch(request));
   },
 };


### PR DESCRIPTION
## Summary

Security-hardening pass over the contact form pipeline and response headers, verified end-to-end (24 unit tests, 4 e2e tests incl. a live Turnstile widget render, lint, `npm audit` clean, headers checked against local `wrangler dev`).

### Changes

- **CSP: drop `'unsafe-inline'` from `script-src`.** Astro was inlining the form script into the HTML, which forced the unsafe directive and neutralized CSP as an XSS defense. `vite.build.assetsInlineLimit: 0` now makes all scripts external files. Also tightened `img-src https:` → `'self' data:` and added `object-src 'none'`.
- **Apply security headers to Worker-handled responses.** `POST /contact` responses previously had no security headers — only asset responses did (via `public/_headers`, since the asset layer serves files without invoking the Worker). Both header sets updated and cross-referenced with a keep-in-sync note.
- **Server-side input length limits** on all contact form fields (name 200, email 320, phone 100, website 500, message 5000), mirrored by client `maxlength` attributes. Previously anyone passing Turnstile could post unbounded payloads.
- **Fail closed instead of 500** on malformed POST bodies (`request.formData()` throw) and Turnstile siteverify outages.
- **`X-XSS-Protection: 1; mode=block` → `0`** — the legacy auditor is deprecated and abusable for XS-leaks; CSP is the real defense.
- **SMTP envelope fix (correctness, found in passing):** `MAIL FROM` was sent as `<"display name" <addr>>`, invalid per RFC 5321 — now sends the bare address.
- **Unit tests** for every new rejection path.

### Review focus

The CSP change is the riskiest part. E2e confirms the Turnstile widget renders under the new policy, but please glance at the PR preview deployment's browser console for CSP violations before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)