### PR TITLE
ci: remove redundant preview deploy PR comment

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -10,7 +10,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
   deployments: write
 
 jobs:
@@ -66,11 +65,4 @@ jobs:
               environment_url: previewUrl,
               log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               description: "Deployed to Cloudflare Workers",
-            });
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `Preview deployed: ${previewUrl}`,
             });


### PR DESCRIPTION
## Summary
- Removes the `createComment` step from `.github/workflows/preview-deploy.yml` — since #48 the workflow already registers a proper GitHub Deployment with an `environment_url`, which GitHub surfaces in the PR's "Environments" section. The extra issue comment with the preview link was redundant.
- Drops the now-unused `pull-requests: write` permission (only `deployments: write` is needed to create the deployment/deployment status).

## Context: duplicate builds per PR
Investigated the "does every PR build/deploy twice?" question. Confirmed via PR #58's check runs: yes, currently every PR runs **two independent pipelines**:
1. `Deploy preview` (this repo's `.github/workflows/preview-deploy.yml`, using `wrangler-action`)
2. `Workers Builds: stefanhoth-com` — Cloudflare's own git-integration CI/CD, configured in the Cloudflare dashboard (Workers & Pages → stefanhoth-com → Settings → Build), independent of this repo's GitHub Actions

This is a Cloudflare dashboard setting, not something in this repo's code, so it can't be fixed via this PR. To stop the duplicate build/deploy, disable the git integration under the Worker's Build settings in the Cloudflare dashboard (or disable preview deployments there), since `preview-deploy.yml` already covers PR previews explicitly.

## Test plan
- [x] Reviewed the diff — no functional change to the deployment itself, only removes the comment step and the permission it required


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qj7eRRxSLUZon1iYFBFomP)_