### PR TITLE
ci: harden GitHub Actions workflows (supply chain + token hygiene)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
@@ -30,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
@@ -42,6 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
@@ -60,6 +66,8 @@ jobs:
       options: --ipc=host
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Cache npm dependencies
         uses: actions/cache@v6
         with:

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -13,11 +13,15 @@ permissions:
   deployments: write
 
 jobs:
-  preview:
-    name: Deploy preview
+  # Build runs npm lifecycle scripts (untrusted third-party code), so it is
+  # isolated from the deploy job, which holds the Cloudflare secrets.
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
@@ -26,9 +30,29 @@ jobs:
       - run: npm run build
         env:
           PUBLIC_TURNSTILE_SITE_KEY: 0x4AAAAAADw4zdHIwQQk6qDu
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
+
+  preview:
+    name: Deploy preview
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout provides wrangler.jsonc, worker/, and functions/ only —
+      # no npm install runs in this job.
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v7
+        with:
+          name: dist
+          path: dist/
       - name: Upload preview version
         id: deploy
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         env:
           PR_ALIAS: pr-${{ github.event.number }}
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "config:recommended"
+        "config:recommended",
+        "helpers:pinGitHubActionDigests"
     ],
     "ignorePaths": [
         ".agents/**"


### PR DESCRIPTION
Applies the findings from a GitHub Actions hardening review of `ci.yml` and `preview-deploy.yml`. No behavior change to what CI runs or what gets deployed — same alias, same GitHub deployment registration.

## Changes

### 🟠 Pin `cloudflare/wrangler-action` to a commit SHA
`@v4` is a mutable tag; a compromised upstream could repoint it at code that runs with `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`. Now pinned to `ebbaa15` (`v4.0.0`).

### 🟡 Split preview deploy into build → deploy jobs
`npm ci` executes third-party lifecycle scripts. Previously they ran on the same runner as the secret-bearing wrangler step, so a malicious dependency (e.g. arriving via a Renovate update PR, which runs with secrets) could tamper with the runner before the deploy step. Now the build job has no secrets, and the deploy job runs no npm installs — `dist/` is handed over via a 1-day artifact. Wrangler-action installs its own wrangler pinned from package.json.

### 🔵 `persist-credentials: false` on every checkout
No step needs git auth after checkout, so the `GITHUB_TOKEN` no longer lingers in `.git/config` where lifecycle scripts could read it.

### 🔵 Renovate: `helpers:pinGitHubActionDigests`
Renovate will SHA-pin the remaining `actions/*` references on its next run and keep all digests updated; the existing `pin`/`digest` automerge rule handles those PRs.

## Verified
- YAML lint passes on both workflows
- `public/` contains no dotfiles, so `upload-artifact`'s default hidden-file exclusion drops nothing from `dist/`
- Deploy job needs only `wrangler.jsonc`, `worker/`, `functions/` (from checkout) + `dist/` (from artifact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)