### PR TITLE
Vault content layer: Astro Content Layer + Obsidian vault pages

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -132,6 +132,11 @@ The contact form POSTs to `/contact`, which the Worker routes to `onRequestPost`
 
 The frontend widget needs `PUBLIC_TURNSTILE_SITE_KEY` at build time.
 
+## Git Workflow
+
+- Commit incrementally per logical step, not one bundled commit at the end.
+- Once a chunk of work is done and verified (build/tests pass), push the branch and open a PR automatically — no need to ask each time. This does not extend to merging a PR or force-pushing; those still require explicit confirmation.
+
 ## Recent Changes
 
 - Migrated hosting from Netlify to Cloudflare Workers (PR #44)

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,8 @@
 import mdx from "@astrojs/mdx";
 import react from "@astrojs/react";
+import { unified } from "@astrojs/markdown-remark";
 import tailwindcss from "@tailwindcss/vite";
+import wikiLink from "remark-wiki-link";
 import { defineConfig } from "astro/config";
 
 // https://astro.build/config
@@ -9,6 +11,21 @@ export default defineConfig({
   output: "static",
   site: "https://stefanhoth.com",
   base: "/",
+
+  markdown: {
+    processor: unified({
+      remarkPlugins: [
+        [
+          wikiLink,
+          {
+            aliasDivider: "|",
+            pathFormat: "obsidian-short",
+            hrefTemplate: (permalink) => `/${permalink}`,
+          },
+        ],
+      ],
+    }),
+  },
 
   vite: {
     plugins: [tailwindcss()],

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,9 +1,17 @@
+import { readdirSync } from "node:fs";
 import mdx from "@astrojs/mdx";
 import react from "@astrojs/react";
 import { unified } from "@astrojs/markdown-remark";
 import tailwindcss from "@tailwindcss/vite";
 import wikiLink from "remark-wiki-link";
 import { defineConfig } from "astro/config";
+
+// Vault filenames are the source of truth for slugs (kebab-case, flat
+// directory) — used both to resolve [[Wikilink]] targets to those slugs
+// and to mark links to non-existent pages as "new".
+const vaultPermalinks = readdirSync(new URL("./vault", import.meta.url))
+  .filter((name) => name.endsWith(".md"))
+  .map((name) => name.replace(/\.md$/, ""));
 
 // https://astro.build/config
 export default defineConfig({
@@ -21,6 +29,8 @@ export default defineConfig({
             aliasDivider: "|",
             pathFormat: "obsidian-short",
             hrefTemplate: (permalink) => `/${permalink}`,
+            permalinks: vaultPermalinks,
+            pageResolver: (name) => [name.trim().toLowerCase().replace(/\s+/g, "-")],
           },
         ],
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,12 @@
         "tw-animate-css": "^1.4.0"
       },
       "devDependencies": {
+        "@astrojs/markdown-remark": "^7.2.1",
         "@biomejs/biome": "^2.3.10",
         "@playwright/test": "^1.61.1",
+        "@tailwindcss/typography": "^0.5.20",
         "jsdom": "^29.1.1",
+        "remark-wiki-link": "^2.0.1",
         "vitest": "^4.1.10",
         "wrangler": "^4.107.0"
       }
@@ -612,6 +615,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -3122,6 +3135,19 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
+      "integrity": "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
+      }
+    },
     "node_modules/@tailwindcss/vite": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.2.tgz",
@@ -3958,6 +3984,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/csso": {
@@ -5759,6 +5798,176 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-wiki-link": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-wiki-link/-/mdast-util-wiki-link-0.1.2.tgz",
+      "integrity": "sha512-DTcDyOxKDo3pB3fc0zQlD8myfQjYkW4hazUKI9PUyhtoj9JBeHC2eIdlVXmaT22bZkFAVU2d47B6y2jVKGoUQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "mdast-util-to-markdown": "^0.6.5"
+      }
+    },
+    "node_modules/mdast-util-wiki-link/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-wiki-link/node_modules/character-entities": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-wiki-link/node_modules/character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-wiki-link/node_modules/character-reference-invalid": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-wiki-link/node_modules/is-alphabetical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-wiki-link/node_modules/is-alphanumerical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-wiki-link/node_modules/is-decimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-wiki-link/node_modules/is-hexadecimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-wiki-link/node_modules/longest-streak": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-wiki-link/node_modules/mdast-util-to-markdown": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
+      "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "longest-streak": "^2.0.0",
+        "mdast-util-to-string": "^2.0.0",
+        "parse-entities": "^2.0.0",
+        "repeat-string": "^1.0.0",
+        "zwitch": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-wiki-link/node_modules/mdast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-wiki-link/node_modules/parse-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-wiki-link/node_modules/zwitch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
+      "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -6055,6 +6264,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-wiki-link": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/micromark-extension-wiki-link/-/micromark-extension-wiki-link-0.0.4.tgz",
+      "integrity": "sha512-dJc8AfnoU8BHkN+7fWZvIS20SMsMS1ZlxQUn6We67MqeKbOiEDZV5eEvCpwqGBijbJbxX3Kxz879L4K9HIiOvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -7450,6 +7669,20 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -7766,6 +7999,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-wiki-link": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/remark-wiki-link/-/remark-wiki-link-2.0.1.tgz",
+      "integrity": "sha512-F8Eut1E7GWfFm4ZDTI6/4ejeZEHZgnVk6E933Yqd/ssYsc4AyI32aGakxwsGcEzbbE7dkWi1EfLlGAdGgOZOsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.4.4",
+        "mdast-util-wiki-link": "^0.1.2",
+        "micromark-extension-wiki-link": "^0.0.4"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/require-from-string": {
@@ -8678,6 +8933,13 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,12 @@
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
+    "@astrojs/markdown-remark": "^7.2.1",
     "@biomejs/biome": "^2.3.10",
     "@playwright/test": "^1.61.1",
+    "@tailwindcss/typography": "^0.5.20",
     "jsdom": "^29.1.1",
+    "remark-wiki-link": "^2.0.1",
     "vitest": "^4.1.10",
     "wrangler": "^4.107.0"
   }

--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -3,11 +3,6 @@
 ---
 
 <div class="about">
-  <p>
-    I build engineering organizations where teams ship sustainably and stakeholders trust the process. Nine years as an engineering manager at Novoda, ResearchGate, and SoSafe. Most of the work happens at the org level: structure that doesn't kill culture, hiring that scales without diluting, and platform decisions that earn their adoption rather than mandate it.
-  </p>
-  <p>
-    On the side I'm building <a href="https://github.com/stefanhoth/crusty-proxy" target="_blank" rel="noopener noreferrer">crusty-proxy</a>, a small MCP security proxy that sits between my self-hosted AI agent and the external APIs it can call. Closer to "responsible disclosure" than to "AI security": the agent runs on a need-to-know basis.
-  </p>
+  <slot />
 </div>
 

--- a/src/components/JobHunt.astro
+++ b/src/components/JobHunt.astro
@@ -1,8 +1,14 @@
 ---
-// Job hunt banner component
+interface Props {
+  text: string;
+}
+
+const { text } = Astro.props;
+// jobhunt is a flat frontmatter string (not markdown body), so Astro won't
+// render it — a single **bold** marker is all Obsidian's editor needs, so
+// we translate just that instead of pulling in a full markdown parser.
+const html = text.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
 ---
 
-<div class="job-hunt">
-  <strong>Open to new roles:</strong> Director or Head of Engineering, remote-first. Ideally with a founder or CTO building out their first engineering leadership layer, or a scale-up that needs structure brought into an established team.
-</div>
+<div class="job-hunt" set:html={html} />
 

--- a/src/components/Profile.astro
+++ b/src/components/Profile.astro
@@ -1,11 +1,15 @@
 ---
-// Profile component with photo, name, and tagline
+interface Props {
+  tagline: string;
+}
+
+const { tagline } = Astro.props;
 ---
 
 <div class="profile">
   <img src="/img/profile/profile.png" alt="Stefan Hoth" class="photo" width="300" height="300" />
   <h1>Stefan Hoth</h1>
-  <p class="tagline">Engineering Leader · Building high-trust engineering organizations</p>
+  <p class="tagline">{tagline}</p>
   <p class="location">Based near Dresden, Germany</p>
 </div>
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,32 @@
+import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
+
+const home = defineCollection({
+  loader: glob({ pattern: "home.md", base: "./vault" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    tagline: z.string(),
+    jobhunt: z.string().optional(),
+  }),
+});
+
+const pages = defineCollection({
+  loader: glob({ pattern: ["*.md", "!home.md"], base: "./vault" }),
+  schema: z
+    .object({
+      title: z.string().optional(),
+      description: z.string().optional(),
+      publish: z.boolean().default(false),
+    })
+    .superRefine((data, ctx) => {
+      if (data.publish && !data.title) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "title ist Pflicht, wenn publish: true",
+        });
+      }
+    }),
+});
+
+export const collections = { home, pages };

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -8,7 +8,7 @@ const {
 ---
 
 <!doctype html>
-<html lang="de">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -1,0 +1,19 @@
+---
+import { getCollection, render } from "astro:content";
+import Layout from "@/layouts/Layout.astro";
+
+export async function getStaticPaths() {
+  const pages = await getCollection("pages", ({ data }) => data.publish);
+  return pages.map((page) => ({ params: { slug: page.id }, props: { page } }));
+}
+
+const { page } = Astro.props;
+const { Content } = await render(page);
+---
+
+<Layout title={page.data.title} description={page.data.description}>
+  <article class="prose">
+    <h1>{page.data.title}</h1>
+    <Content />
+  </article>
+</Layout>

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -13,7 +13,6 @@ const { Content } = await render(page);
 
 <Layout title={page.data.title} description={page.data.description}>
   <article class="prose">
-    <h1>{page.data.title}</h1>
     <Content />
   </article>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import { getEntry, render } from "astro:content";
 import About from "@/components/About.astro";
 import ContactForm from "@/components/ContactForm.astro";
 import JobHunt from "@/components/JobHunt.astro";
@@ -6,15 +7,17 @@ import LatestPost from "@/components/LatestPost.astro";
 import Links from "@/components/Links.astro";
 import Profile from "@/components/Profile.astro";
 import Layout from "@/layouts/Layout.astro";
+
+const home = await getEntry("home", "home");
+const { Content: AboutContent } = await render(home);
 ---
 
-<Layout
-  title="Stefan Hoth | Engineering Leader"
-  description="Engineering Leader building high-trust engineering organizations. Currently open to Director or Head of Engineering roles, remote-first."
->
-  <Profile />
-  <JobHunt />
-  <About />
+<Layout title={home.data.title} description={home.data.description}>
+  <Profile tagline={home.data.tagline} />
+  {home.data.jobhunt && <JobHunt text={home.data.jobhunt} />}
+  <About>
+    <AboutContent />
+  </About>
   <LatestPost />
   <Links />
   <ContactForm />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@plugin "@tailwindcss/typography";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,6 +4,29 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* Tailwind Typography ships light-mode prose colors regardless of theme.
+   Point its CSS variables at the site's own theme variables (Layout.astro),
+   which already flip with prefers-color-scheme, instead of duplicating a
+   dark-mode media query here. */
+.prose {
+  --tw-prose-body: var(--text);
+  --tw-prose-headings: var(--text);
+  --tw-prose-lead: var(--text);
+  --tw-prose-links: var(--accent);
+  --tw-prose-bold: var(--text);
+  --tw-prose-counters: var(--text);
+  --tw-prose-bullets: var(--text);
+  --tw-prose-hr: var(--border);
+  --tw-prose-quotes: var(--text);
+  --tw-prose-quote-borders: var(--border);
+  --tw-prose-captions: var(--text);
+  --tw-prose-code: var(--text);
+  --tw-prose-pre-code: var(--text);
+  --tw-prose-pre-bg: var(--card-bg);
+  --tw-prose-th-borders: var(--border);
+  --tw-prose-td-borders: var(--border);
+}
+
 @theme inline {
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);

--- a/vault/employee-readme.md
+++ b/vault/employee-readme.md
@@ -1,0 +1,84 @@
+---
+title: Employee README
+description: What you can expect from Stefan Hoth as a direct report or colleague.
+publish: true
+cssclasses:
+  - website-page
+created: 2026-06-10
+---
+
+# Employee README
+
+The [[Manager README]] explains how I work as a manager. This one goes the other direction: what you can expect from me as a direct report.
+
+Same caveat applies: if this doesn't match your experience of me, tell me. The document is less useful than the conversation.
+
+---
+
+## How I work
+
+**I think by talking.** I'm an external processor. I don't arrive at conversations with my position fully formed. I work toward clarity through dialogue - asking questions, testing ideas out loud, sometimes changing my mind mid-sentence. If you need me to come to a discussion with a written position first, tell me and I will. But in most cases, the live conversation is where my thinking actually develops.
+
+**I stay close to the work.** I read code, I dig into the details, I want to understand how things actually function before I have opinions about them. This makes me slower to form views than someone who is comfortable reasoning at a distance - and more confident in the views I do form.
+
+**I cross team boundaries.** I notice connections between problems and people that aren't obvious from inside a single team. I'll reach across naturally - to other teams, to product, to design, and sometimes to HR, Legal, or Marketing. I see it as working toward a shared goal, not as wandering off my patch. Occasionally it means I'm seemingly working outside my role. If you think I'm on the wrong topic, let's talk about it.
+
+**I step into unclear responsibility.** If I see a gap - something that's a risk or has potential to improve substantially - I'll step up to cover it, or at least figure out who else can. This connects to the boundary-crossing above: I'm not assigning work to other teams. I'm just not comfortable watching something go wrong when I could do something about it.
+
+---
+
+## What I need from you
+
+**Autonomy over how, clarity over what.** I need to understand what we're trying to achieve and why. If I have that, I'll figure out the approach. If I don't have that, I'll spend energy on the wrong things.
+
+**Context, openness, and trust.** The full picture, not a filtered version of it. I make better decisions when I understand the business situation, the constraints, and the reasoning behind decisions that affect my work. More broadly: I work best when we can speak openly with each other - no need to read between the lines, no political maneuvering to protect ourselves. I'll give you that directness. I need it back.
+
+**A thinking partner, not just a hierarchy.** I work well with managers who want to think through problems together, not just assign and review. I don't need to be told what to think - I need someone to think alongside.
+
+**Feedback when I'm off track.** I won't always know when I've misread a situation or a priority. If something's not working, I need you to tell me directly. I'll take it well.
+
+---
+
+## What you can count on
+
+I'll tell you when I disagree. Politely, with reasoning, and at the right moment - not in a way that undermines decisions that have already been made, but before they are. If I've said I'm aligned, I am.
+
+I'll name things that aren't working - in the team, in the process, in the org. I don't complain without being willing to do something about it.
+
+I'll stay technically credible. I won't make decisions about engineering work from a position of deliberate ignorance.
+
+If the situation is hard - reorganization, cuts, uncertainty - I'll hold my team together and be honest with them about what I know and what I don't. I won't pretend things are fine when they're not.
+
+I'll show up as myself. No performance.
+
+---
+
+## My quirks
+
+**I can feel out of place in very hierarchical settings.** I work best in environments where seniority doesn't determine who gets heard. In rooms where I feel like I need to impress rather than contribute, I'm less effective. I'm aware of this and I work on it. But if you're building a collaborative no-ego environment, I'll thrive faster.
+
+**Too many unrelated small topics slow me down.** Fragmented attention is where my best work doesn't happen. I do better with fewer things I can go deep on than with a long list of things I touch briefly.
+
+**Bureaucracy costs me energy.** Necessary process: fine. Process for its own sake: I'll eventually push back on it, and I should probably flag that upfront.
+
+**I need to talk before I can write.** For complex or ambiguous problems, a 20-minute conversation will produce a better written output than an hour of solo thinking. If my first written draft on something difficult looks rough, that's often why.
+
+---
+
+## Remote and async
+
+I've worked remotely since 2014. Distributed-by-default is how I think about collaboration - documentation, async communication, written decisions. I don't need an office to be effective.
+
+What doesn't work: being the only person outside the office in a hybrid setup. If the team defaults to in-person and I'm the exception, I'll be systematically excluded from the conversations that matter. I need the team to be genuinely distributed - or genuinely co-located, with quarterly travel from me.
+
+---
+
+## How to give me feedback
+
+Directly and specifically. "When you did X in that situation, the effect was Y" is exactly the format I need. I don't need it softened. I do need it to be about something concrete, not a general impression.
+
+If something is recurring, tell me sooner rather than saving it. I can't course-correct on information I don't have.
+
+---
+
+*Last updated: June 2026.*

--- a/vault/home.md
+++ b/vault/home.md
@@ -1,0 +1,10 @@
+---
+title: Stefan Hoth | Engineering Leader
+description: Engineering Leader building high-trust engineering organizations. Currently open to Director or Head of Engineering roles, remote-first.
+tagline: Engineering Leader · Building high-trust engineering organizations
+jobhunt: "**Open to new roles:** Director or Head of Engineering, remote-first. Ideally with a founder or CTO building out their first engineering leadership layer, or a scale-up that needs structure brought into an established team."
+---
+
+I build engineering organizations where teams ship sustainably and stakeholders trust the process. Nine years as an engineering manager at Novoda, ResearchGate, and SoSafe. Most of the work happens at the org level: structure that doesn't kill culture, hiring that scales without diluting, and platform decisions that earn their adoption rather than mandate it.
+
+On the side I'm building [crusty-proxy](https://github.com/stefanhoth/crusty-proxy), a small MCP security proxy that sits between my self-hosted AI agent and the external APIs it can call. Closer to "responsible disclosure" than to "AI security": the agent runs on a need-to-know basis.

--- a/vault/manager-readme.md
+++ b/vault/manager-readme.md
@@ -1,0 +1,104 @@
+---
+title: Manager README
+description: What you can expect from me as a manager.
+publish: true
+cssclasses:
+  - website-page
+created: 2026-06-10
+---
+
+# Manager README
+
+This is not a policy document. It's an attempt to save us a few months of figuring each other out.
+
+Everything in here is based on how I've seen myself work over nine years as a manager. Some of it is a deliberate choice. Some of it is just how I'm wired. Where I've seen myself cause friction, I've tried to flag it.
+
+If anything in here turns out to be wrong about me - or just doesn't match your experience - tell me. I'd rather update the document than have you quietly work around a description of me that no longer fits.
+
+---
+
+## My job
+
+I see my job as three things:
+
+**Clearing the path.** Removing the obstacles that slow your work down - unclear priorities, missing context, organizational friction that has no good reason to exist.
+
+**Shaping the environment.** How the team makes decisions, what we celebrate, how we give each other feedback, what processes we use and which ones we've outgrown. These things compound quietly in both directions. I consider this part of my job, and yours too.
+
+**Growing the people.** Helping you figure out where you want to go and making sure the conditions exist for you to get there.
+
+What my job is not: making your technical decisions for you, or deciding how you organize your work. I'll have opinions. I'll share them. The call is yours.
+
+---
+
+## How I communicate
+
+**Async by default.** I write things down. I expect you to do the same. The written record is not bureaucracy - it's how distributed work functions.
+
+**When to message me:** Whenever. I don't expect you to time messages to my calendar. Outside working hours, don't count on a quick reply - and I won't message you at 11pm expecting one either.
+
+**When to call me:** When you're stuck on something where talking it through is faster than writing. When something is urgent and async isn't working. When you feel like it.
+
+**In meetings:** I try to only schedule meetings with a clear purpose and a clear output. If you leave a meeting I organized and you're not sure what just happened or why you were there - tell me.
+
+---
+
+## What I expect from you
+
+**Own your work.** Not in the motivational-poster sense. In the practical sense: know what you're doing and why, have a view on the right next step, and flag problems before they become crises. I'm not a good safety net for work you've stopped paying attention to.
+
+**Ask for help early.** There's a version of ownership that tips into not asking for help until something has burned down. That's not what I mean. The earlier I know about a blocker, the more options we have - and we can figure out the best next step together.
+
+**Tell me what's not working in the environment.** This is important. I want to hear about rituals that have stopped adding value, processes that create friction without purpose, dynamics in the team that feel off, things I do that make your work harder, and policies from the company that you think we should push back on. You don't have to have a solution. You just have to be willing to name it.
+
+**Have opinions.** Especially if they're inconvenient. I'd rather have a difficult conversation than make a decision without relevant information someone in the room was holding back.
+
+---
+
+## What you can expect from me
+
+**1:1s are your time.** I'll come with things I want to discuss, but your agenda goes first. Use the time for whatever is most useful to you - working through a decision, getting context, thinking out loud, or just talking. If you find our 1:1s aren't useful, tell me and we'll change the format.
+
+**I'll give you the context I have.** Not everything is mine to share, but I won't filter context that affects your work. If I'm not telling you something, I'll tell you I'm not telling you and why.
+
+**Feedback will be direct and specific.** Not brutal, not sandwiched. Delivered privately when it's personal, in the moment when it's situational. If I haven't given you meaningful feedback in a while, ask me - it either means I have nothing useful to say, or I've been lazy about it.
+
+**I can represent your interests best when I have the full picture.** If something's going wrong - with the work, with the team, with how you're feeling about the job - I need to know. I can work with the truth. It's a lot harder when I'm working from assumptions.
+
+---
+
+## My quirks
+
+**I ask a lot of "why" questions.** Not as a challenge. I'm trying to understand the situation well enough to actually help. If it feels like an interrogation, tell me to stop and just tell me what you need.
+
+**I'm an external processor.** I don't arrive at meetings with my thinking finished. I think by talking. If I'm asking questions in a conversation that seem basic, I'm probably not questioning your competence - I'm finding my way to a shared understanding. If you need me to come more prepared, tell me.
+
+**I stay technically close.** I read code, I look at pipelines, I have views on architecture. Not to second-guess you, but because I lose the ability to have useful conversations about the work if I stop paying attention to it. If this ever feels like I'm hovering rather than helping, say so.
+
+**I sometimes go quiet in group settings.** Usually it means I'm still processing, not that I've checked out or that I'm unhappy. If the silence seems weird, poke me.
+
+---
+
+## Feedback
+
+I give feedback directly and promptly. I don't save it for performance reviews.
+
+I try to make it specific: what I observed, what the impact was, what I'd do differently. If a piece of feedback I give you doesn't meet that bar, push back and ask me to be more concrete.
+
+How to give me feedback: the same way. Direct and specific is fine. The easiest version is just "when you did X, it had this effect on me / the team / the work." You can also write it down if that's easier. I won't treat it as an attack.
+
+If something is bothering you about how I work, I'd rather hear it from you than piece it together later.
+
+---
+
+## Career and growth
+
+You're in the driver's seat. I'm not going to push you toward a particular path - toward management, toward staff engineering, toward staying put. The direction is yours.
+
+What I can do: help you find where your goals and the company's direction align - that's usually where the biggest impact happens, give you honest feedback on where you are relative to where you want to go, and create opportunities to work on things that matter for your development.
+
+If you want to have a career conversation, just ask. It doesn't need to be a performance review.
+
+---
+
+*Last updated: June 2026.*

--- a/vault/projects.md
+++ b/vault/projects.md
@@ -1,0 +1,21 @@
+---
+title: Projects
+description: A few things I've built on the side.
+publish: true
+---
+
+# Projects
+
+A few things I've built on the side — mostly scratching my own itches around AI agents, job hunting, and home automation.
+
+## [STARlog](https://github.com/stefanhoth/starlog)
+
+Interview prep tool for the STAR method (Situation, Task, Action, Result). Speak or paste a rough description of something that happened, and Gemini turns it into a polished, interview-ready story — then maps it against the competencies a specific job posting is likely to probe for, so you can see your gaps before the interview does. Everything runs in the browser; nothing leaves your machine except the API calls made with your own key.
+
+## [crusty-proxy](https://github.com/stefanhoth/crusty-proxy)
+
+A small MCP security proxy that sits between my self-hosted AI agent (OpenClaw) and the external APIs it can call. It holds all the credentials and enforces an allowlist, so the agent itself never sees an API key — closer to "responsible disclosure" than to "AI security": the agent runs on a need-to-know basis.
+
+## [paperless-ngx-cli](https://github.com/stefanhoth/paperless-ngx-cli)
+
+A terminal client for Paperless-NGX, my self-hosted document archive. Search, inspect metadata, and trigger bulk operations without opening a browser — built as a single static binary so it drops straight into shell scripts, cron jobs, and AI agent workflows.


### PR DESCRIPTION
## Summary
- Adds an Astro Content Layer over a flat `vault/*.md` directory (`home` and `pages` collections), replacing hardcoded homepage copy with vault-driven content.
- Converts `Profile`, `JobHunt`, `About` to props/slot; adds a dynamic `[slug].astro` route for any vault page with `publish: true`.
- Adds `remark-wiki-link` (swapped in for the plan's originally-named `@portaljs/remark-wiki-link`, which is broken against the current unified/mdast-util v2 stack) and `@tailwindcss/typography`, with prose colors mapped to the site's existing theme variables so dark mode stays legible.
- Populates the vault: `home.md`, `manager-readme.md` + `employee-readme.md` (synced from the OpenClaw Obsidian vault, cross-linked via `[[wikilink]]`), and `projects.md` (STARlog, crusty-proxy, paperless-ngx-cli).
- Fixes a stale `lang="de"` on an otherwise all-English site.

Second step of the vault-structure plan (`docs/plans/2026-07-05-obsidian-cms-vault-struktur.md`), following the Brand Refresh (#64).

## Test plan
- [x] `npm run build` — clean, all 4 pages (`/`, `/manager-readme`, `/employee-readme`, `/projects`) generate
- [x] `npm run test` — 24 unit tests pass
- [x] `npm run test:e2e` — contact form suite passes against local build+preview
- [x] `npm run lint` — no new issues (pre-existing Biome version-mismatch infos only)
- [x] Manually verified in browser preview: homepage regression, both README pages, wikilink navigation, light + dark mode contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)