### PR TITLE
Automate Obsidian vault sync to main via GitHub Actions

### DIFF
--- a/.github/workflows/sync-vault.yml
+++ b/.github/workflows/sync-vault.yml
@@ -38,8 +38,15 @@ jobs:
           cache: npm
       - run: npm ci
 
+      # obsidian-headless is a devDependency, not a global install — put its
+      # bin on PATH directly instead of going through npx. `npx ob` would
+      # also match the unrelated "ob" package on the npm registry, so it's
+      # not safe to rely on npx falling back correctly in every environment.
+      - name: Add local node_modules/.bin to PATH
+        run: echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
+
       - name: Log in to Obsidian Sync
-        run: npx ob login --email "$OBSIDIAN_EMAIL" --password "$OBSIDIAN_PASSWORD"
+        run: ob login --email "$OBSIDIAN_EMAIL" --password "$OBSIDIAN_PASSWORD"
         env:
           OBSIDIAN_EMAIL: ${{ secrets.OBSIDIAN_USER }}
           OBSIDIAN_PASSWORD: ${{ secrets.OBSIDIAN_PASS }}
@@ -50,16 +57,16 @@ jobs:
           if [ -n "$OBSIDIAN_E2EE_PASSWORD" ]; then
             ARGS+=(--password "$OBSIDIAN_E2EE_PASSWORD")
           fi
-          npx ob sync-setup "${ARGS[@]}"
+          ob sync-setup "${ARGS[@]}"
         env:
           OBSIDIAN_VAULT_NAME: ${{ secrets.OBSIDIAN_VAULT }}
           OBSIDIAN_E2EE_PASSWORD: ${{ secrets.OBSIDIAN_E2EE }}
 
       - name: Restrict sync to pull-only
-        run: npx ob sync-config --path ./vault --mode pull-only
+        run: ob sync-config --path ./vault --mode pull-only
 
       - name: Pull latest vault content
-        run: npx ob sync --path ./vault
+        run: ob sync --path ./vault
 
       - name: Check for changes
         id: changes

--- a/.github/workflows/sync-vault.yml
+++ b/.github/workflows/sync-vault.yml
@@ -1,0 +1,83 @@
+name: Sync Obsidian Vault
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: sync-vault
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: Sync vault from Obsidian
+    runs-on: ubuntu-latest
+    steps:
+      # persist-credentials: false — npm ci below runs third-party postinstall
+      # scripts (e.g. better-sqlite3's), so the write-scoped GITHUB_TOKEN is
+      # kept out of the git config until the final push step, which sets it
+      # explicitly and only for that one command.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+
+      - name: Log in to Obsidian Sync
+        run: npx ob login --email "$OBSIDIAN_EMAIL" --password "$OBSIDIAN_PASSWORD"
+        env:
+          OBSIDIAN_EMAIL: ${{ secrets.OBSIDIAN_EMAIL }}
+          OBSIDIAN_PASSWORD: ${{ secrets.OBSIDIAN_PASSWORD }}
+
+      - name: Link local vault directory to the remote vault
+        run: |
+          ARGS=(--vault "$OBSIDIAN_VAULT_NAME" --path vault/ --device-name github-actions-sync)
+          if [ -n "$OBSIDIAN_E2EE_PASSWORD" ]; then
+            ARGS+=(--password "$OBSIDIAN_E2EE_PASSWORD")
+          fi
+          npx ob sync-setup "${ARGS[@]}"
+        env:
+          OBSIDIAN_VAULT_NAME: ${{ secrets.OBSIDIAN_VAULT_NAME }}
+          OBSIDIAN_E2EE_PASSWORD: ${{ secrets.OBSIDIAN_E2EE_PASSWORD }}
+
+      - name: Restrict sync to pull-only
+        run: npx ob sync-config --path vault/ --mode pull-only
+
+      - name: Pull latest vault content
+        run: npx ob sync --path vault/
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git status --porcelain vault/ | grep -q .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Guards against broken frontmatter reaching main: a direct push here
+      # authenticated with GITHUB_TOKEN does not trigger ci.yml (GitHub skips
+      # workflow runs triggered by the default token), so this is the only
+      # build validation the synced content gets before landing on main.
+      - name: Validate build
+        if: steps.changes.outputs.changed == 'true'
+        run: npm run build
+
+      - name: Commit and push vault changes
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git add vault/
+          git commit -m "chore(vault): sync from Obsidian"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/sync-vault.yml
+++ b/.github/workflows/sync-vault.yml
@@ -4,6 +4,14 @@ on:
   schedule:
     - cron: "*/30 * * * *"
   workflow_dispatch:
+  # Lets an external caller (e.g. a shortcut, an Obsidian plugin, a webhook
+  # receiver) trigger a sync on demand via the GitHub API:
+  #   POST /repos/stefanhoth/stefanhoth.com/dispatches
+  #   { "event_type": "sync-vault" }
+  # Requires a PAT (classic: "repo" scope, fine-grained: "Contents: write") —
+  # the built-in GITHUB_TOKEN cannot call this endpoint.
+  repository_dispatch:
+    types: [sync-vault]
 
 concurrency:
   group: sync-vault
@@ -33,25 +41,25 @@ jobs:
       - name: Log in to Obsidian Sync
         run: npx ob login --email "$OBSIDIAN_EMAIL" --password "$OBSIDIAN_PASSWORD"
         env:
-          OBSIDIAN_EMAIL: ${{ secrets.OBSIDIAN_EMAIL }}
-          OBSIDIAN_PASSWORD: ${{ secrets.OBSIDIAN_PASSWORD }}
+          OBSIDIAN_EMAIL: ${{ secrets.OBSIDIAN_USER }}
+          OBSIDIAN_PASSWORD: ${{ secrets.OBSIDIAN_PASS }}
 
       - name: Link local vault directory to the remote vault
         run: |
-          ARGS=(--vault "$OBSIDIAN_VAULT_NAME" --path vault/ --device-name github-actions-sync)
+          ARGS=(--vault "$OBSIDIAN_VAULT_NAME" --path ./vault --device-name github-action-website-publish)
           if [ -n "$OBSIDIAN_E2EE_PASSWORD" ]; then
             ARGS+=(--password "$OBSIDIAN_E2EE_PASSWORD")
           fi
           npx ob sync-setup "${ARGS[@]}"
         env:
-          OBSIDIAN_VAULT_NAME: ${{ secrets.OBSIDIAN_VAULT_NAME }}
-          OBSIDIAN_E2EE_PASSWORD: ${{ secrets.OBSIDIAN_E2EE_PASSWORD }}
+          OBSIDIAN_VAULT_NAME: ${{ secrets.OBSIDIAN_VAULT }}
+          OBSIDIAN_E2EE_PASSWORD: ${{ secrets.OBSIDIAN_E2EE }}
 
       - name: Restrict sync to pull-only
-        run: npx ob sync-config --path vault/ --mode pull-only
+        run: npx ob sync-config --path ./vault --mode pull-only
 
       - name: Pull latest vault content
-        run: npx ob sync --path vault/
+        run: npx ob sync --path ./vault
 
       - name: Check for changes
         id: changes

--- a/.github/workflows/sync-vault.yml
+++ b/.github/workflows/sync-vault.yml
@@ -46,21 +46,21 @@ jobs:
         run: echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
 
       - name: Log in to Obsidian Sync
-        run: ob login --email "$OBSIDIAN_EMAIL" --password "$OBSIDIAN_PASSWORD"
         env:
           OBSIDIAN_EMAIL: ${{ secrets.OBSIDIAN_USER }}
           OBSIDIAN_PASSWORD: ${{ secrets.OBSIDIAN_PASS }}
+        run: ob login --email "$OBSIDIAN_EMAIL" --password "$OBSIDIAN_PASSWORD"
 
       - name: Link local vault directory to the remote vault
+        env:
+          OBSIDIAN_VAULT_NAME: ${{ secrets.OBSIDIAN_VAULT }}
+          OBSIDIAN_E2EE_PASSWORD: ${{ secrets.OBSIDIAN_E2EE }}
         run: |
           ARGS=(--vault "$OBSIDIAN_VAULT_NAME" --path ./vault --device-name github-action-website-publish)
           if [ -n "$OBSIDIAN_E2EE_PASSWORD" ]; then
             ARGS+=(--password "$OBSIDIAN_E2EE_PASSWORD")
           fi
           ob sync-setup "${ARGS[@]}"
-        env:
-          OBSIDIAN_VAULT_NAME: ${{ secrets.OBSIDIAN_VAULT }}
-          OBSIDIAN_E2EE_PASSWORD: ${{ secrets.OBSIDIAN_E2EE }}
 
       - name: Restrict sync to pull-only
         run: ob sync-config --path ./vault --mode pull-only
@@ -87,6 +87,8 @@ jobs:
 
       - name: Commit and push vault changes
         if: steps.changes.outputs.changed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -94,5 +96,3 @@ jobs:
           git add vault/
           git commit -m "chore(vault): sync from Obsidian"
           git push
-        env:
-          GITHUB_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ dist/
 # Wrangler
 .wrangler/
 
+# Obsidian Sync local state (github.com/obsidianmd/obsidian-headless)
+vault/.obsidian/
+
 # Test artifacts
 test-results/
 playwright-report/

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -103,7 +103,7 @@ The site runs on Cloudflare Workers. A single Worker (`worker/index.js`, configu
 - `public/_headers` caches `/_astro/*` for 1 year with the immutable directive
 
 **Deploys**:
-- Production: `npm run worker:deploy` (builds, then `wrangler deploy`)
+- Production: automatic — the Cloudflare GitHub App ("Cloudflare Workers and Pages", installed on this repo) builds and deploys `stefanhoth-com` to production on every push to `main`, reported as a `Workers Builds: stefanhoth-com` check run. This is Cloudflare's native git integration (configured in the Cloudflare dashboard, not a file in this repo) — it is separate from and runs in addition to `ci.yml`. `npm run worker:deploy` still works for a manual/local deploy (e.g. to push a change without going through `main`), but isn't the normal path.
 - PR previews: `.github/workflows/preview-deploy.yml` builds the site and uploads a preview version via `cloudflare/wrangler-action` with a `pr-<number>` alias, then registers a GitHub deployment and comments the preview URL (`https://pr-<number>-stefanhoth-com.stefanhoth-de.workers.dev`) on the PR
 - CI (`.github/workflows/ci.yml`) runs lint, build, unit tests, and Playwright e2e on every PR and push to main
 - Local Worker testing: `npm run worker:dev` (secrets from `.dev.vars`)

--- a/docs/plans/2026-07-05-obsidian-sync-headless-pipeline.md
+++ b/docs/plans/2026-07-05-obsidian-sync-headless-pipeline.md
@@ -1,13 +1,14 @@
-# Plan: Obsidian Sync Headless → GitHub Repo → Netlify
+# Plan: Obsidian Sync Headless → GitHub Repo → Cloudflare Workers
 
 **Datum:** 2026-07-05
-**Status:** In Planung
+**Aktualisiert:** 2026-07-08 — Netlify-Annahmen durch den tatsächlichen Cloudflare-Workers-Flow ersetzt, CLI-Kommandos gegen die offizielle `obsidian-headless`-Doku verifiziert.
+**Status:** Umgesetzt (Workflow `sync-vault.yml`) — Repository-Secrets müssen noch manuell angelegt werden.
 
 ---
 
 ## Ziel
 
-Vault-Inhalte aus Obsidian Sync automatisch ins GitHub-Repository ziehen, ohne die Desktop-App öffnen zu müssen. Netlify baut die Astro-Site dann wie bisher aus dem Repo.
+Vault-Inhalte aus Obsidian Sync automatisch ins GitHub-Repository ziehen, ohne die Desktop-App öffnen zu müssen.
 
 ## Flow
 
@@ -15,86 +16,96 @@ Vault-Inhalte aus Obsidian Sync automatisch ins GitHub-Repository ziehen, ohne d
 Obsidian App (any device)
         ↓  bearbeiten
 Obsidian Sync (Cloud)
-        ↓  ob sync (GitHub Actions, geplant)
-GitHub Repo  →  vault/
-        ↓  push auf main
-Netlify (auto-deploy)
+        ↓  ob sync (GitHub Actions, alle 30 Min + manuell)
+GitHub Repo  →  vault/  (Commit auf main)
         ↓
-stefanhoth.com
+        (kein Auto-Deploy bei Push auf main — Deploy bleibt der bestehende
+         manuelle Schritt: `npm run worker:deploy`, oder ein PR mit
+         Preview-Deploy via preview-deploy.yml)
+stefanhoth.com  (nach manuellem Deploy)
 ```
+
+**Wichtiger Unterschied zum ursprünglichen Plan:** Das Repo lief beim Schreiben dieses Plans noch auf Netlify (Auto-Deploy bei jedem Push auf `main`). Seit PR #44 läuft es auf Cloudflare Workers — es gibt **keinen automatischen Produktions-Deploy bei Push auf main**. `ci.yml` läuft bei Push auf main (Lint/Build/Test), `preview-deploy.yml` nur bei Pull Requests. Der Sync-Workflow committet also Vault-Änderungen auf `main`, aber die Seite geht erst live, wenn jemand `npm run worker:deploy` ausführt (oder das über einen separaten Auto-Deploy-Workflow ergänzt wird — das ist bewusst **nicht** Teil dieses Schritts, siehe „Bestehende Infrastruktur bleibt unverändert" unten).
 
 ## Tool
 
-`obsidian-headless` — offizielles npm-CLI von Obsidian (open beta).
-Dokumentation: https://obsidian.md/help/sync/headless
+`obsidian-headless` — offizielles npm-CLI von Obsidian (`npm install -g obsidian-headless`, Node ≥ 22, bin heißt `ob`).
+Quellen: [obsidian.md/help/sync/headless](https://obsidian.md/help/sync/headless), [github.com/obsidianmd/obsidian-headless](https://github.com/obsidianmd/obsidian-headless).
 
 Benötigt: aktives Obsidian Sync Abonnement.
 
+Relevante Kommandos (verifiziert):
+- `ob login --email <email> --password <password>` — nicht-interaktiver Login. **Kein `--mfa`-Flag mit statischem Secret möglich für Dauerbetrieb** — falls das Sync-Konto 2FA/MFA aktiv hat, schlägt der automatisierte Login fehl (siehe Offene Punkte).
+- `ob sync-list-remote` — Remote-Vaults auflisten (einmalig zur Namensermittlung).
+- `ob sync-setup --vault "<Name>" --path vault/ --device-name github-actions-sync [--password <e2ee-pw>]` — lokalen Ordner mit Remote-Vault verknüpfen.
+- `ob sync-config --path vault/ --mode pull-only` — Sync auf reine Pull-Richtung beschränken, damit der Workflow niemals versehentlich etwas in den Obsidian-Vault zurückschreibt.
+- `ob sync --path vault/` — einmaliger Sync-Lauf.
+
 ---
 
-## Geplante Änderungen am Repository
+## Umgesetzte Änderungen am Repository
 
 ### 1. Vault-Verzeichnis
 
-```
-vault/    ← neue Ablage für die gesyncten Markdown-Dateien
-```
+`vault/` existiert bereits seit PR #67 (Content-Layer-Ingestion).
 
 ### 2. `.gitignore`
 
-Lokale Obsidian-Metadaten vom Repo ausschließen:
+Lokale Obsidian-Sync-Metadaten vom Repo ausgeschlossen (Config-Dir-Default ist `.obsidian`, wird bei jedem CI-Lauf frisch angelegt und nicht committet):
 
 ```
-vault/.obsidian/workspace.json
-vault/.obsidian/workspace-mobile.json
-vault/.obsidian/cache
-vault/.obsidian/plugins/
-vault/.obsidian/themes/
-vault/.obsidian/snippets/
+vault/.obsidian/
 ```
 
 ### 3. `package.json`
 
-Neue Scripts:
-
 ```json
 "sync:vault": "ob sync --path vault/",
-"sync:vault:setup": "ob sync-setup --vault \"<VAULT-NAME>\" --path vault/"
+"sync:vault:setup": "ob sync-setup --path vault/"
 ```
 
-`obsidian-headless` als devDependency.
+`obsidian-headless` als devDependency (statt global) — damit `npm ci` es reproduzierbar mitinstalliert und `ob` über `node_modules/.bin` verfügbar ist.
 
 ### 4. GitHub Actions Workflow
 
-Neue Datei: `.github/workflows/sync-vault.yml`
+`.github/workflows/sync-vault.yml`
 
-- Trigger: Zeitplan (alle 30 Minuten) + manuell (`workflow_dispatch`)
-- Schritte: Login → Vault verknüpfen → Sync → Commit & Push
-- Commit-Message enthält `[skip ci]` um Endlosschleifen zu vermeiden
-- Credentials kommen aus Repository Secrets (werden nicht im Code gespeichert)
+- Trigger: `schedule` (alle 30 Minuten) + `workflow_dispatch`
+- Schritte: `npm ci` → Login → Vault verknüpfen (idempotent, da Runner jedes Mal frisch startet) → Pull-only-Modus setzen → Sync → **`npm run build` als Validierungs-Gate** → Commit & Push, nur wenn der Build durchläuft
+- **Kein `[skip ci]`**: Ein direkter Push mit dem Standard-`GITHUB_TOKEN` löst laut GitHub ohnehin keine Folge-Workflows aus (Rekursionsschutz) — `ci.yml` würde auf diesem Commit gar nicht laufen. Deshalb läuft die Build-Validierung (das eigentliche Sicherheitsnetz für kaputte Frontmatter aus `docs/plans/2026-07-05-obsidian-cms-vault-struktur.md`) **innerhalb** des Sync-Jobs selbst, vor dem Commit — schlägt der Build fehl, wird nichts committet und der Job schlägt sichtbar fehl.
+- Credentials aus Repository Secrets (werden nicht im Code gespeichert)
+- `permissions: contents: write`, sonst nichts
+- `checkout` mit `persist-credentials: false`: `npm ci` führt Postinstall-Skripte Dritter aus (u. a. für `better-sqlite3`, eine native Abhängigkeit von `obsidian-headless`); der schreibende `GITHUB_TOKEN` wird erst im letzten Schritt (Commit & Push) explizit in die Remote-URL eingesetzt, damit er während `npm ci` und den Obsidian-CLI-Schritten nicht im Git-Credential-Store liegt
 
 ---
 
-## Voraussetzungen (einmalig manuell)
+## Voraussetzungen (einmalig manuell, durch Stefan)
 
 1. Vault-Namen ermitteln:
    ```bash
    npx obsidian-headless ob login
    npx obsidian-headless ob sync-list-remote
    ```
-2. GitHub Repository Secrets anlegen (Names: `OBSIDIAN_EMAIL`, `OBSIDIAN_PASSWORD`, `OBSIDIAN_VAULT_NAME`)
-3. Optional: E2EE-Passwort als Secret, falls der Vault end-to-end verschlüsselt ist
+2. GitHub Repository Secrets anlegen: `OBSIDIAN_EMAIL`, `OBSIDIAN_PASSWORD`, `OBSIDIAN_VAULT_NAME`
+3. Optional: `OBSIDIAN_E2EE_PASSWORD`, falls der Vault Ende-zu-Ende-verschlüsselt ist
+4. Ersten Lauf manuell über `workflow_dispatch` anstoßen und Ergebnis prüfen, bevor man sich auf den 30-Minuten-Zeitplan verlässt
 
 ---
 
+## Offene Punkte
+
+- **2FA/MFA**: Falls auf dem Obsidian-Account, der für den Sync verwendet wird, 2FA aktiv ist, schlägt `ob login --email --password` in der Automation fehl. Optionen: separates Sync-Konto ohne 2FA, oder 2FA für dieses Konto deaktivieren. Muss vor dem ersten produktiven Lauf geklärt werden.
+- **Deploy-Trigger**: Aktuell landet ein Vault-Update nur auf `main`, geht aber nicht automatisch live. Falls gewünscht, wäre ein separater `on: push (main)`-Workflow für `wrangler deploy` ein eigener, hier bewusst ausgeklammerter nächster Schritt.
+- **Session-Persistenz**: Die Doku von `obsidian-headless` spezifiziert nicht genau, wie/wo Login-Sessions gespeichert werden. Der Workflow loggt sich bei jedem Lauf frisch ein (Runner ist ephemer) — funktioniert, ist aber ggf. langsamer als ein persistenter Client. Sollte sich das nach den ersten Läufen als unzuverlässig erweisen (Rate-Limiting etc.), muss das CLI-Verhalten erneut geprüft werden.
+
 ## Hinweis
 
-Obsidian Sync Headless und die Desktop-App sollten **nicht gleichzeitig auf demselben Device** gegen denselben Vault synchronisieren — das kann zu Konflikten führen.
+Obsidian Sync Headless und die Desktop-App sollten **nicht gleichzeitig auf demselben Device** gegen denselben Vault synchronisieren — das kann zu Konflikten führen. Der `pull-only`-Modus im Workflow reduziert dieses Risiko zusätzlich, da der Workflow niemals in den Vault zurückschreibt.
 
 ---
 
 ## Bestehende Infrastruktur bleibt unverändert
 
-- Astro + Tailwind (Haupt-Site)
-- Netlify (Deployment)
+- Astro + Tailwind + Content Layer (Haupt-Site, seit PR #67)
+- Cloudflare Workers (Deployment, weiterhin manuell via `npm run worker:deploy`)
 - Kein Obsidian Publish Abonnement erforderlich

--- a/docs/plans/2026-07-05-obsidian-sync-headless-pipeline.md
+++ b/docs/plans/2026-07-05-obsidian-sync-headless-pipeline.md
@@ -1,8 +1,8 @@
 # Plan: Obsidian Sync Headless → GitHub Repo → Cloudflare Workers
 
 **Datum:** 2026-07-05
-**Aktualisiert:** 2026-07-08 — Netlify-Annahmen durch den tatsächlichen Cloudflare-Workers-Flow ersetzt, CLI-Kommandos gegen die offizielle `obsidian-headless`-Doku verifiziert.
-**Status:** Umgesetzt (Workflow `sync-vault.yml`) — Repository-Secrets müssen noch manuell angelegt werden.
+**Aktualisiert:** 2026-07-08 — Netlify-Annahmen durch den tatsächlichen Cloudflare-Workers-Flow ersetzt, CLI-Kommandos gegen die offizielle `obsidian-headless`-Doku verifiziert. Korrigiert: entgegen einer ersten (falschen) Version dieses Dokuments deployt Cloudflare bei Push auf `main` automatisch in Produktion, über die Cloudflare-GitHub-App ("Cloudflare Workers and Pages", Dashboard-Integration, kein Workflow in diesem Repo) — sichtbar als Check-Run `Workers Builds: stefanhoth-com`. Ein Vault-Sync auf `main` geht damit **automatisch live**, sobald Cloudflares eigener Build erfolgreich ist.
+**Status:** Umgesetzt (Workflow `sync-vault.yml`) — Repository-Secrets angelegt (`OBSIDIAN_USER`/`PASS`/`VAULT`/`E2EE`).
 
 ---
 
@@ -16,16 +16,15 @@ Vault-Inhalte aus Obsidian Sync automatisch ins GitHub-Repository ziehen, ohne d
 Obsidian App (any device)
         ↓  bearbeiten
 Obsidian Sync (Cloud)
-        ↓  ob sync (GitHub Actions, alle 30 Min + manuell)
-GitHub Repo  →  vault/  (Commit auf main)
+        ↓  ob sync (GitHub Actions, alle 30 Min + manuell + Webhook)
+GitHub Repo  →  vault/  (Commit auf main, nur wenn npm run build durchläuft)
         ↓
-        (kein Auto-Deploy bei Push auf main — Deploy bleibt der bestehende
-         manuelle Schritt: `npm run worker:deploy`, oder ein PR mit
-         Preview-Deploy via preview-deploy.yml)
-stefanhoth.com  (nach manuellem Deploy)
+        Cloudflare Workers Builds (GitHub-App-Integration, kein Workflow
+        in diesem Repo — baut + deployt automatisch bei jedem Push auf main)
+stefanhoth.com  (live, sobald der Cloudflare-Build erfolgreich ist)
 ```
 
-**Wichtiger Unterschied zum ursprünglichen Plan:** Das Repo lief beim Schreiben dieses Plans noch auf Netlify (Auto-Deploy bei jedem Push auf `main`). Seit PR #44 läuft es auf Cloudflare Workers — es gibt **keinen automatischen Produktions-Deploy bei Push auf main**. `ci.yml` läuft bei Push auf main (Lint/Build/Test), `preview-deploy.yml` nur bei Pull Requests. Der Sync-Workflow committet also Vault-Änderungen auf `main`, aber die Seite geht erst live, wenn jemand `npm run worker:deploy` ausführt (oder das über einen separaten Auto-Deploy-Workflow ergänzt wird — das ist bewusst **nicht** Teil dieses Schritts, siehe „Bestehende Infrastruktur bleibt unverändert" unten).
+**Unterschied zum ursprünglichen Plan:** Das Repo lief beim Schreiben dieses Plans noch auf Netlify (Auto-Deploy bei jedem Push auf `main`). Seit PR #44 läuft es auf Cloudflare Workers — der Mechanismus dahinter hat sich geändert, das Verhalten aber nicht: Die Cloudflare-GitHub-App ("Cloudflare Workers and Pages") ist auf das Repo installiert und deployt bei jedem Push auf `main` automatisch nach Produktion (Check-Run `Workers Builds: stefanhoth-com`, sichtbar z. B. unter github.com/stefanhoth/stefanhoth.com/runs/&lt;id&gt;). Das läuft unabhängig von `ci.yml` (Lint/Build/Test) und `preview-deploy.yml` (nur bei PRs) — beide bleiben unverändert bestehen. Ein Vault-Sync, der auf `main` committet wird, geht also **automatisch live**, sobald Cloudflares eigener Build erfolgreich durchläuft. Das `npm run build`-Gate im Sync-Workflow (siehe unten) verhindert zusätzlich, dass kaputte Frontmatter überhaupt erst auf `main` landet — Cloudflares Build ist die zweite, nachgelagerte Absicherung.
 
 ## Tool
 
@@ -96,7 +95,6 @@ vault/.obsidian/
 
 ## Offene Punkte
 
-- **Deploy-Trigger**: Aktuell landet ein Vault-Update nur auf `main`, geht aber nicht automatisch live. Falls gewünscht, wäre ein separater `on: push (main)`-Workflow für `wrangler deploy` ein eigener, hier bewusst ausgeklammerter nächster Schritt.
 - **Session-Persistenz**: Die Doku von `obsidian-headless` spezifiziert nicht genau, wie/wo Login-Sessions gespeichert werden. Der Workflow loggt sich bei jedem Lauf frisch ein (Runner ist ephemer) — funktioniert, ist aber ggf. langsamer als ein persistenter Client. Sollte sich das nach den ersten Läufen als unzuverlässig erweisen (Rate-Limiting etc.), muss das CLI-Verhalten erneut geprüft werden.
 
 ## Hinweis
@@ -108,5 +106,5 @@ Obsidian Sync Headless und die Desktop-App sollten **nicht gleichzeitig auf dems
 ## Bestehende Infrastruktur bleibt unverändert
 
 - Astro + Tailwind + Content Layer (Haupt-Site, seit PR #67)
-- Cloudflare Workers (Deployment, weiterhin manuell via `npm run worker:deploy`)
+- Cloudflare Workers Builds (automatisches Deployment bei Push auf `main`, über die Cloudflare-GitHub-App — unverändert seit PR #44, `npm run worker:deploy` bleibt zusätzlich für manuelle/lokale Deploys verfügbar)
 - Kein Obsidian Publish Abonnement erforderlich

--- a/docs/plans/2026-07-05-obsidian-sync-headless-pipeline.md
+++ b/docs/plans/2026-07-05-obsidian-sync-headless-pipeline.md
@@ -74,6 +74,7 @@ vault/.obsidian/
 - Trigger: `schedule` (alle 30 Minuten) + `workflow_dispatch` + `repository_dispatch` (Typ `sync-vault`) — Letzteres erlaubt einen On-Demand-Trigger von außen per Webhook: `POST /repos/stefanhoth/stefanhoth.com/dispatches` mit `{"event_type": "sync-vault"}`, authentifiziert mit einem PAT (classic: Scope `repo`; fine-grained: Permission `Contents: write`). Der eingebaute `GITHUB_TOKEN` kann diesen Endpunkt nicht selbst aufrufen — dafür ist ein separates, von Stefan verwaltetes PAT nötig, das nicht Teil dieses Workflows ist.
 - Schritte: `npm ci` → Login → Vault verknüpfen (idempotent, da Runner jedes Mal frisch startet) → Pull-only-Modus setzen → Sync → **`npm run build` als Validierungs-Gate** → Commit & Push, nur wenn der Build durchläuft
 - **Kein `[skip ci]`**: Ein direkter Push mit dem Standard-`GITHUB_TOKEN` löst laut GitHub ohnehin keine Folge-Workflows aus (Rekursionsschutz) — `ci.yml` würde auf diesem Commit gar nicht laufen. Deshalb läuft die Build-Validierung (das eigentliche Sicherheitsnetz für kaputte Frontmatter aus `docs/plans/2026-07-05-obsidian-cms-vault-struktur.md`) **innerhalb** des Sync-Jobs selbst, vor dem Commit — schlägt der Build fehl, wird nichts committet und der Job schlägt sichtbar fehl.
+- **Deploy wird trotzdem getriggert**: Der `GITHUB_TOKEN`-Rekursionsschutz betrifft nur GitHub-Actions-Workflows im selben Repo. Cloudflares GitHub-App bekommt den Push-Webhook auch bei Bot-Pushes zugestellt ([bestätigt in GitHubs Community-Diskussion #25702](https://github.com/orgs/community/discussions/25702)) und deployt den Sync-Commit ganz normal — Content-Update und Deployment sind also **nicht** voneinander getrennt.
 - Credentials aus Repository Secrets (werden nicht im Code gespeichert)
 - `permissions: contents: write`, sonst nichts
 - `checkout` mit `persist-credentials: false`: `npm ci` führt Postinstall-Skripte Dritter aus (u. a. für `better-sqlite3`, eine native Abhängigkeit von `obsidian-headless`); der schreibende `GITHUB_TOKEN` wird erst im letzten Schritt (Commit & Push) explizit in die Remote-URL eingesetzt, damit er während `npm ci` und den Obsidian-CLI-Schritten nicht im Git-Credential-Store liegt
@@ -89,7 +90,9 @@ vault/.obsidian/
    ```
 2. GitHub Repository Secrets angelegt: `OBSIDIAN_USER`, `OBSIDIAN_PASS`, `OBSIDIAN_VAULT`
 3. Optional: `OBSIDIAN_E2EE`, falls der Vault Ende-zu-Ende-verschlüsselt ist
-4. Ersten Lauf manuell über `workflow_dispatch` anstoßen und Ergebnis prüfen, bevor man sich auf den 30-Minuten-Zeitplan verlässt
+4. Ersten Lauf manuell über `workflow_dispatch` anstoßen und Ergebnis prüfen, bevor man sich auf den 30-Minuten-Zeitplan verlässt. Dabei auch verifizieren:
+   - dass der Sync-Commit auf `main` einen `Workers Builds: stefanhoth-com`-Check-Run auslöst (= Deploy läuft)
+   - dass im Cloudflare-Dashboard (**Settings → Builds**) keine [Build Watch Paths](https://developers.cloudflare.com/workers/ci-cd/builds/build-watch-paths/) konfiguriert sind, die `vault/` ausschließen — sonst würde Cloudflare den Build für reine Vault-Commits überspringen und Content-Update und Deployment wären doch getrennt
 
 ---
 

--- a/docs/plans/2026-07-05-obsidian-sync-headless-pipeline.md
+++ b/docs/plans/2026-07-05-obsidian-sync-headless-pipeline.md
@@ -34,12 +34,14 @@ Quellen: [obsidian.md/help/sync/headless](https://obsidian.md/help/sync/headless
 
 Benötigt: aktives Obsidian Sync Abonnement.
 
+2FA/MFA für das verwendete Sync-Konto ist **deaktiviert** (Entscheidung von Stefan) — nicht-interaktiver Login ist damit unproblematisch.
+
 Relevante Kommandos (verifiziert):
-- `ob login --email <email> --password <password>` — nicht-interaktiver Login. **Kein `--mfa`-Flag mit statischem Secret möglich für Dauerbetrieb** — falls das Sync-Konto 2FA/MFA aktiv hat, schlägt der automatisierte Login fehl (siehe Offene Punkte).
+- `ob login --email <email> --password <password>` — nicht-interaktiver Login.
 - `ob sync-list-remote` — Remote-Vaults auflisten (einmalig zur Namensermittlung).
-- `ob sync-setup --vault "<Name>" --path vault/ --device-name github-actions-sync [--password <e2ee-pw>]` — lokalen Ordner mit Remote-Vault verknüpfen.
-- `ob sync-config --path vault/ --mode pull-only` — Sync auf reine Pull-Richtung beschränken, damit der Workflow niemals versehentlich etwas in den Obsidian-Vault zurückschreibt.
-- `ob sync --path vault/` — einmaliger Sync-Lauf.
+- `ob sync-setup --vault "<Name>" --path ./vault --device-name github-action-website-publish [--password <e2ee-pw>]` — lokalen Ordner mit Remote-Vault verknüpfen.
+- `ob sync-config --path ./vault --mode pull-only` — zusätzlich zum ursprünglich vorgesehenen 3-Schritte-Flow ergänzt, beschränkt Sync auf reine Pull-Richtung, damit der Workflow niemals versehentlich etwas in den Obsidian-Vault zurückschreibt.
+- `ob sync --path ./vault` — einmaliger Sync-Lauf.
 
 ---
 
@@ -60,8 +62,8 @@ vault/.obsidian/
 ### 3. `package.json`
 
 ```json
-"sync:vault": "ob sync --path vault/",
-"sync:vault:setup": "ob sync-setup --path vault/"
+"sync:vault": "ob sync --path ./vault",
+"sync:vault:setup": "ob sync-setup --path ./vault"
 ```
 
 `obsidian-headless` als devDependency (statt global) — damit `npm ci` es reproduzierbar mitinstalliert und `ob` über `node_modules/.bin` verfügbar ist.
@@ -70,7 +72,7 @@ vault/.obsidian/
 
 `.github/workflows/sync-vault.yml`
 
-- Trigger: `schedule` (alle 30 Minuten) + `workflow_dispatch`
+- Trigger: `schedule` (alle 30 Minuten) + `workflow_dispatch` + `repository_dispatch` (Typ `sync-vault`) — Letzteres erlaubt einen On-Demand-Trigger von außen per Webhook: `POST /repos/stefanhoth/stefanhoth.com/dispatches` mit `{"event_type": "sync-vault"}`, authentifiziert mit einem PAT (classic: Scope `repo`; fine-grained: Permission `Contents: write`). Der eingebaute `GITHUB_TOKEN` kann diesen Endpunkt nicht selbst aufrufen — dafür ist ein separates, von Stefan verwaltetes PAT nötig, das nicht Teil dieses Workflows ist.
 - Schritte: `npm ci` → Login → Vault verknüpfen (idempotent, da Runner jedes Mal frisch startet) → Pull-only-Modus setzen → Sync → **`npm run build` als Validierungs-Gate** → Commit & Push, nur wenn der Build durchläuft
 - **Kein `[skip ci]`**: Ein direkter Push mit dem Standard-`GITHUB_TOKEN` löst laut GitHub ohnehin keine Folge-Workflows aus (Rekursionsschutz) — `ci.yml` würde auf diesem Commit gar nicht laufen. Deshalb läuft die Build-Validierung (das eigentliche Sicherheitsnetz für kaputte Frontmatter aus `docs/plans/2026-07-05-obsidian-cms-vault-struktur.md`) **innerhalb** des Sync-Jobs selbst, vor dem Commit — schlägt der Build fehl, wird nichts committet und der Job schlägt sichtbar fehl.
 - Credentials aus Repository Secrets (werden nicht im Code gespeichert)
@@ -86,15 +88,14 @@ vault/.obsidian/
    npx obsidian-headless ob login
    npx obsidian-headless ob sync-list-remote
    ```
-2. GitHub Repository Secrets anlegen: `OBSIDIAN_EMAIL`, `OBSIDIAN_PASSWORD`, `OBSIDIAN_VAULT_NAME`
-3. Optional: `OBSIDIAN_E2EE_PASSWORD`, falls der Vault Ende-zu-Ende-verschlüsselt ist
+2. GitHub Repository Secrets angelegt: `OBSIDIAN_USER`, `OBSIDIAN_PASS`, `OBSIDIAN_VAULT`
+3. Optional: `OBSIDIAN_E2EE`, falls der Vault Ende-zu-Ende-verschlüsselt ist
 4. Ersten Lauf manuell über `workflow_dispatch` anstoßen und Ergebnis prüfen, bevor man sich auf den 30-Minuten-Zeitplan verlässt
 
 ---
 
 ## Offene Punkte
 
-- **2FA/MFA**: Falls auf dem Obsidian-Account, der für den Sync verwendet wird, 2FA aktiv ist, schlägt `ob login --email --password` in der Automation fehl. Optionen: separates Sync-Konto ohne 2FA, oder 2FA für dieses Konto deaktivieren. Muss vor dem ersten produktiven Lauf geklärt werden.
 - **Deploy-Trigger**: Aktuell landet ein Vault-Update nur auf `main`, geht aber nicht automatisch live. Falls gewünscht, wäre ein separater `on: push (main)`-Workflow für `wrangler deploy` ein eigener, hier bewusst ausgeklammerter nächster Schritt.
 - **Session-Persistenz**: Die Doku von `obsidian-headless` spezifiziert nicht genau, wie/wo Login-Sessions gespeichert werden. Der Workflow loggt sich bei jedem Lauf frisch ein (Runner ist ephemer) — funktioniert, ist aber ggf. langsamer als ein persistenter Client. Sollte sich das nach den ersten Läufen als unzuverlässig erweisen (Rate-Limiting etc.), muss das CLI-Verhalten erneut geprüft werden.
 

--- a/docs/plans/2026-07-05-obsidian-sync-headless-pipeline.md
+++ b/docs/plans/2026-07-05-obsidian-sync-headless-pipeline.md
@@ -83,10 +83,10 @@ vault/.obsidian/
 
 ## Voraussetzungen (einmalig manuell, durch Stefan)
 
-1. Vault-Namen ermitteln:
+1. Vault-Namen ermitteln (das Paket exportiert nur ein Binary namens `ob`, nicht `obsidian-headless` — daher `npx -p obsidian-headless`, nicht `npx obsidian-headless`):
    ```bash
-   npx obsidian-headless ob login
-   npx obsidian-headless ob sync-list-remote
+   npx -p obsidian-headless ob login
+   npx -p obsidian-headless ob sync-list-remote
    ```
 2. GitHub Repository Secrets angelegt: `OBSIDIAN_USER`, `OBSIDIAN_PASS`, `OBSIDIAN_VAULT`
 3. Optional: `OBSIDIAN_E2EE`, falls der Vault Ende-zu-Ende-verschlüsselt ist

--- a/docs/plans/2026-07-05-obsidian-sync-headless-pipeline.md
+++ b/docs/plans/2026-07-05-obsidian-sync-headless-pipeline.md
@@ -60,12 +60,7 @@ vault/.obsidian/
 
 ### 3. `package.json`
 
-```json
-"sync:vault": "ob sync --path ./vault",
-"sync:vault:setup": "ob sync-setup --path ./vault"
-```
-
-`obsidian-headless` als devDependency (statt global) — damit `npm ci` es reproduzierbar mitinstalliert und `ob` über `node_modules/.bin` verfügbar ist.
+`obsidian-headless` als devDependency (statt global) — damit `npm ci` es reproduzierbar mitinstalliert und `ob` über `node_modules/.bin` verfügbar ist. Bewusst **keine** `sync:vault*`-Scripts: Der Workflow ruft `ob` direkt mit vollen Flags auf, und als lokale Convenience wären sie kaum mehr als eine dünne Hülle (`sync-setup` bräuchte den Vault-Namen ohnehin bei jedem Aufruf per `-- --vault "..."`). Für einen manuellen Lauf: `node_modules/.bin/ob sync-setup --vault "<Name>" --path ./vault`.
 
 ### 4. GitHub Actions Workflow
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@playwright/test": "^1.61.1",
         "@tailwindcss/typography": "^0.5.20",
         "jsdom": "^29.1.1",
+        "obsidian-headless": "^0.0.12",
         "remark-wiki-link": "^2.0.1",
         "vitest": "^4.1.10",
         "wrangler": "^4.107.0"
@@ -3673,6 +3674,27 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.42",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
@@ -3685,6 +3707,21 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
+      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -3693,6 +3730,28 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/blake3-wasm": {
@@ -3739,6 +3798,31 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/caniuse-lite": {
@@ -3835,6 +3919,13 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
@@ -4088,6 +4179,32 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/defu": {
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
@@ -4227,6 +4344,16 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
       "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
       "license": "ISC"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.21.6",
@@ -4460,6 +4587,16 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -4517,6 +4654,13 @@
         }
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/flattie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
@@ -4546,6 +4690,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -4584,6 +4735,13 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/github-slugger": {
       "version": "2.0.0",
@@ -4880,6 +5038,41 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -6652,6 +6845,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/miniflare": {
       "version": "4.20260706.0",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260706.0.tgz",
@@ -7259,6 +7465,23 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -7292,6 +7515,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/neotraverse": {
       "version": "0.6.18",
       "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
@@ -7312,6 +7542,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-fetch-native": {
@@ -7356,6 +7612,42 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/obsidian-headless": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/obsidian-headless/-/obsidian-headless-0.0.12.tgz",
+      "integrity": "sha512-d/TI1iqCZbkTCfa1zLi6a99MRVmiApvtxgP2JgDRjRAYkHgxvhGtT5aTxSXE6BXXJG4g9xADbrsRQrSqvsl1Rg==",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "dev": true,
+      "license": "UNLICENSED",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "better-sqlite3": "12.6.2",
+        "commander": "14.0.3"
+      },
+      "bin": {
+        "ob": "cli.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/obsidian-headless/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
@@ -7385,6 +7677,16 @@
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/oniguruma-parser": {
       "version": "0.12.2",
@@ -7634,6 +7936,34 @@
         "node": ">=4"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -7662,6 +7992,17 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -7677,6 +8018,22 @@
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
     },
     "node_modules/react": {
       "version": "19.2.7",
@@ -7706,6 +8063,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -8093,6 +8465,27 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "license": "MIT"
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/satteri": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.4.tgz",
@@ -8241,6 +8634,53 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -8301,6 +8741,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -8313,6 +8763,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/style-to-js": {
@@ -8405,6 +8865,36 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tiny-inflate": {
@@ -8536,6 +9026,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",
@@ -9251,6 +9754,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.21.0",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
-    "sync:vault": "ob sync --path vault/",
-    "sync:vault:setup": "ob sync-setup --path vault/"
+    "sync:vault": "ob sync --path ./vault",
+    "sync:vault:setup": "ob sync-setup --path ./vault"
   },
   "dependencies": {
     "@astrojs/mdx": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "worker:deploy": "npm run build && wrangler deploy",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "sync:vault": "ob sync --path vault/",
+    "sync:vault:setup": "ob sync-setup --path vault/"
   },
   "dependencies": {
     "@astrojs/mdx": "^7.0.0",
@@ -40,6 +42,7 @@
     "@playwright/test": "^1.61.1",
     "@tailwindcss/typography": "^0.5.20",
     "jsdom": "^29.1.1",
+    "obsidian-headless": "^0.0.12",
     "remark-wiki-link": "^2.0.1",
     "vitest": "^4.1.10",
     "wrangler": "^4.107.0"

--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
     "worker:deploy": "npm run build && wrangler deploy",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:e2e": "playwright test",
-    "sync:vault": "ob sync --path ./vault",
-    "sync:vault:setup": "ob sync-setup --path ./vault"
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@astrojs/mdx": "^7.0.0",


### PR DESCRIPTION
## Summary
This is step 3 of the roadmap from `docs/plans/2026-07-05-obsidian-cms-vault-struktur.md` (step 2, the Content Layer ingestion, landed in #67/#68). It closes the loop so `vault/` content edited in Obsidian reaches `main` — and from there, production — without a manual commit.

- Corrects `docs/plans/2026-07-05-obsidian-sync-headless-pipeline.md`, which still assumed Netlify. Verified the `obsidian-headless` CLI's actual command/flag surface against `ob <command> --help`, not just its docs.
- Adds `.github/workflows/sync-vault.yml`: runs every 30 minutes, on demand (`workflow_dispatch`), or via an external webhook (`repository_dispatch`, event type `sync-vault`, needs a PAT — `GITHUB_TOKEN` can't call the dispatches API). Pulls the vault via `obsidian-headless` (`ob login` → `ob sync-setup` → `ob sync-config --mode pull-only` → `ob sync`), runs `npm run build` as a validation gate (a push authenticated with `GITHUB_TOKEN` doesn't trigger `ci.yml`, so this is the only check before the content lands on `main`), then commits and pushes only if the build passes and content changed.
- Adds `obsidian-headless` as a devDependency, two `npm run sync:vault*` scripts, and gitignores `vault/.obsidian/` (local sync state).
- Hardening: `npm ci` runs with no push-capable credential present (`persist-credentials: false`); the `GITHUB_TOKEN` is only injected into the git remote at the final push step, so a compromised postinstall script during `npm ci` can't reach it.

**Correction from an earlier version of this PR:** I initially wrote that production deploy was still a manual `npm run worker:deploy` step. That was wrong — Cloudflare's own GitHub App ("Cloudflare Workers and Pages") is installed on this repo and builds+deploys to production on every push to `main` (check run `Workers Builds: stefanhoth-com`), independent of any workflow here. So a vault sync that lands on `main` **goes live automatically** once Cloudflare's build succeeds. `CLAUDE.md` and the plan doc are corrected to reflect this.

## Manual setup (done by Stefan)
- Repository secrets `OBSIDIAN_USER`, `OBSIDIAN_PASS`, `OBSIDIAN_VAULT` (and `OBSIDIAN_E2EE` if the vault is E2E-encrypted) — created, and 2FA is disabled on the sync account.
- Still open: trigger the first run manually via `workflow_dispatch` and check the logs before relying on the 30-minute schedule.

## Test plan
- [x] `npm run build`, `npm run lint`, `npm run test` all pass locally (Node 24.18.0, matching `.nvmrc`) with the new `obsidian-headless` devDependency installed
- [x] Verified every `ob` CLI flag used in the workflow against `ob <command> --help` output (login/sync-setup/sync-config/sync) rather than trusting docs alone
- [x] Confirmed `main` has no branch protection blocking a bot push
- [x] Confirmed via `gh api .../commits/main/check-runs` that Cloudflare's Workers Builds app deploys on push to main
- [ ] End-to-end run against the real Obsidian Sync account — can't be done from here; needs a manual `workflow_dispatch` run to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)