### PR TITLE
Route vault sync through a PR + auto-merge instead of direct push

### DIFF
--- a/.github/workflows/sync-vault.yml
+++ b/.github/workflows/sync-vault.yml
@@ -96,15 +96,15 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git checkout -B sync/vault
+          git switch -c chore/sync-vault
           git add vault/
           git commit -m "chore(vault): sync from Obsidian"
-          git push --force origin sync/vault
+          git push --force origin chore/sync-vault
 
-          existing_pr=$(gh pr list --head sync/vault --state open --json number --jq '.[0].number // empty')
+          existing_pr=$(gh pr list --head chore/sync-vault --state open --json number --jq '.[0].number // empty')
           if [ -z "$existing_pr" ]; then
-            gh pr create --base main --head sync/vault \
+            gh pr create --base main --head chore/sync-vault \
               --title "chore(vault): sync from Obsidian" \
               --body "Automated vault sync — opened by .github/workflows/sync-vault.yml."
-            gh pr merge sync/vault --auto --squash
+            gh pr merge chore/sync-vault --auto --squash
           fi

--- a/.github/workflows/sync-vault.yml
+++ b/.github/workflows/sync-vault.yml
@@ -17,18 +17,18 @@ concurrency:
   group: sync-vault
   cancel-in-progress: false
 
+# main is protected by a ruleset requiring a PR with 4 green status checks
+# (Lint/Build/Test/E2E against preview) and a successful "preview" deployment
+# — a direct push is rejected. Nothing here writes with the default
+# GITHUB_TOKEN, so no elevated permissions are needed for it.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   sync:
     name: Sync vault from Obsidian
     runs-on: ubuntu-latest
     steps:
-      # persist-credentials: false — npm ci below runs third-party postinstall
-      # scripts (e.g. better-sqlite3's), so the write-scoped GITHUB_TOKEN is
-      # kept out of the git config until the final push step, which sets it
-      # explicitly and only for that one command.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
@@ -77,22 +77,34 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Guards against broken frontmatter reaching main: a direct push here
-      # authenticated with GITHUB_TOKEN does not trigger ci.yml (GitHub skips
-      # workflow runs triggered by the default token), so this is the only
-      # build validation the synced content gets before landing on main.
+      # First gate: catches broken frontmatter before it's even pushed to a
+      # branch. ci.yml's own Build job is the second, required gate on the PR.
       - name: Validate build
         if: steps.changes.outputs.changed == 'true'
         run: npm run build
 
-      - name: Commit and push vault changes
+      # Pushed and opened with a PAT, not the default GITHUB_TOKEN: pushes and
+      # PR events authenticated with GITHUB_TOKEN don't trigger downstream
+      # workflows, which would leave ci.yml/preview-deploy.yml — and the
+      # required status checks / preview deployment the branch ruleset
+      # demands — never running.
+      - name: Push branch and open/refresh the PR
         if: steps.changes.outputs.changed == 'true'
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_COMMIT_PAT }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git checkout -B sync/vault
           git add vault/
           git commit -m "chore(vault): sync from Obsidian"
-          git push
+          git push --force origin sync/vault
+
+          existing_pr=$(gh pr list --head sync/vault --state open --json number --jq '.[0].number // empty')
+          if [ -z "$existing_pr" ]; then
+            gh pr create --base main --head sync/vault \
+              --title "chore(vault): sync from Obsidian" \
+              --body "Automated vault sync — opened by .github/workflows/sync-vault.yml."
+            gh pr merge sync/vault --auto --squash
+          fi

--- a/docs/plans/2026-07-05-obsidian-sync-headless-pipeline.md
+++ b/docs/plans/2026-07-05-obsidian-sync-headless-pipeline.md
@@ -1,8 +1,9 @@
 # Plan: Obsidian Sync Headless → GitHub Repo → Cloudflare Workers
 
 **Datum:** 2026-07-05
-**Aktualisiert:** 2026-07-08 — Netlify-Annahmen durch den tatsächlichen Cloudflare-Workers-Flow ersetzt, CLI-Kommandos gegen die offizielle `obsidian-headless`-Doku verifiziert. Korrigiert: entgegen einer ersten (falschen) Version dieses Dokuments deployt Cloudflare bei Push auf `main` automatisch in Produktion, über die Cloudflare-GitHub-App ("Cloudflare Workers and Pages", Dashboard-Integration, kein Workflow in diesem Repo) — sichtbar als Check-Run `Workers Builds: stefanhoth-com`. Ein Vault-Sync auf `main` geht damit **automatisch live**, sobald Cloudflares eigener Build erfolgreich ist.
-**Status:** Umgesetzt (Workflow `sync-vault.yml`) — Repository-Secrets angelegt (`OBSIDIAN_USER`/`PASS`/`VAULT`/`E2EE`).
+**Aktualisiert:** 2026-07-08 — Netlify-Annahmen durch den tatsächlichen Cloudflare-Workers-Flow ersetzt, CLI-Kommandos gegen die offizielle `obsidian-headless`-Doku verifiziert. Korrigiert: entgegen einer ersten (falschen) Version dieses Dokuments deployt Cloudflare bei Push auf `main` automatisch in Produktion, über die Cloudflare-GitHub-App ("Cloudflare Workers and Pages", Dashboard-Integration, kein Workflow in diesem Repo) — sichtbar als Check-Run `Workers Builds: stefanhoth-com`. Ein Vault-Sync, der auf `main` landet, geht damit **automatisch live**, sobald Cloudflares eigener Build erfolgreich ist.
+**Zweite Korrektur (nach dem ersten echten Lauf):** Direkter Push auf `main` wird von einer aktiven Repository-Ruleset ("Protect main") abgelehnt — PR Pflicht, 4 grüne Status-Checks (Lint/Build/Test/E2E gegen Preview) und ein erfolgreiches `preview`-Deployment sind Voraussetzung fürs Mergen (0 Approvals nötig). Der Workflow committet daher auf einen festen Branch `sync/vault`, öffnet/aktualisiert dort einen PR und aktiviert Auto-Merge, statt direkt auf `main` zu pushen.
+**Status:** Umgesetzt (Workflow `sync-vault.yml`) — Repository-Secrets angelegt (`OBSIDIAN_USER`/`PASS`/`VAULT`/`E2EE`, `GH_COMMIT_PAT`).
 
 ---
 
@@ -17,14 +18,32 @@ Obsidian App (any device)
         ↓  bearbeiten
 Obsidian Sync (Cloud)
         ↓  ob sync (GitHub Actions, alle 30 Min + manuell + Webhook)
-GitHub Repo  →  vault/  (Commit auf main, nur wenn npm run build durchläuft)
+Branch sync/vault  (force-gepusht, nur wenn npm run build durchläuft)
+        ↓  PR main ← sync/vault (per PAT geöffnet, damit Checks überhaupt laufen)
+ci.yml (Lint/Build/Test) + preview-deploy.yml (Preview-Deployment + E2E)
+        ↓  alle 4 Checks grün + erfolgreiches preview-Deployment
+Auto-Merge (squash) → main
         ↓
         Cloudflare Workers Builds (GitHub-App-Integration, kein Workflow
         in diesem Repo — baut + deployt automatisch bei jedem Push auf main)
 stefanhoth.com  (live, sobald der Cloudflare-Build erfolgreich ist)
 ```
 
-**Unterschied zum ursprünglichen Plan:** Das Repo lief beim Schreiben dieses Plans noch auf Netlify (Auto-Deploy bei jedem Push auf `main`). Seit PR #44 läuft es auf Cloudflare Workers — der Mechanismus dahinter hat sich geändert, das Verhalten aber nicht: Die Cloudflare-GitHub-App ("Cloudflare Workers and Pages") ist auf das Repo installiert und deployt bei jedem Push auf `main` automatisch nach Produktion (Check-Run `Workers Builds: stefanhoth-com`, sichtbar z. B. unter github.com/stefanhoth/stefanhoth.com/runs/&lt;id&gt;). Das läuft unabhängig von `ci.yml` (Lint/Build/Test) und `preview-deploy.yml` (nur bei PRs) — beide bleiben unverändert bestehen. Ein Vault-Sync, der auf `main` committet wird, geht also **automatisch live**, sobald Cloudflares eigener Build erfolgreich durchläuft. Das `npm run build`-Gate im Sync-Workflow (siehe unten) verhindert zusätzlich, dass kaputte Frontmatter überhaupt erst auf `main` landet — Cloudflares Build ist die zweite, nachgelagerte Absicherung.
+**Unterschied zum ursprünglichen Plan:** Das Repo lief beim Schreiben dieses Plans noch auf Netlify (Auto-Deploy bei jedem Push auf `main`). Seit PR #44 läuft es auf Cloudflare Workers — der Mechanismus dahinter hat sich geändert, das Verhalten aber nicht: Die Cloudflare-GitHub-App ("Cloudflare Workers and Pages") ist auf das Repo installiert und deployt bei jedem Push auf `main` automatisch nach Produktion (Check-Run `Workers Builds: stefanhoth-com`). Das läuft unabhängig von `ci.yml` und `preview-deploy.yml` — beide bleiben unverändert bestehen.
+
+**Zweite, wichtigere Abweichung:** Ein direkter Bot-Push auf `main` — egal ob mit dem Standard-`GITHUB_TOKEN` oder einem PAT — wird von der Repository-Ruleset "Protect main" abgelehnt (siehe unten). Der Workflow geht deshalb über einen PR, nicht über einen direkten Commit auf `main`. Das hat einen erwünschten Nebeneffekt: Vault-Syncs durchlaufen jetzt dieselben Qualitäts-Gates (Lint/Build/Test/E2E gegen eine echte Preview-Deployment) wie jede von Hand gemachte Änderung — nicht nur das repo-interne `npm run build`.
+
+### Warum PR statt Direct-Push (Repository-Ruleset)
+
+Die aktive Ruleset **„Protect main"** (`gh api repos/stefanhoth/stefanhoth.com/rulesets/18674761`) verlangt für `main`:
+- Änderungen nur per Pull Request (0 Approvals nötig, keine Code-Owner-Pflicht)
+- 4 grüne Status-Checks: `Lint`, `Build`, `Test`, `E2E against preview` (alle aus `ci.yml`/`preview-deploy.yml`)
+- Ein erfolgreiches Deployment ins Environment `preview` (aus `preview-deploy.yml`)
+- Linear History (nur Squash-Merge ist im Repo überhaupt erlaubt — passt zusammen)
+
+Ein Push mit dem Standard-`GITHUB_TOKEN` scheiterte im ersten echten Testlauf direkt an dieser Regel (`GH013: Repository rule violations`). Zusätzlich gilt: Ereignisse, die mit dem Standard-`GITHUB_TOKEN` ausgelöst werden, lösen laut GitHub **keine** Folge-Workflows aus — das betrifft nicht nur `push`, sondern auch `pull_request`. Ein mit `GITHUB_TOKEN` geöffneter PR hätte also nie die geforderten Checks laufen lassen. Deshalb verwendet der Workflow für Branch-Push **und** PR-Erstellung ein separates PAT (`GH_COMMIT_PAT`), das wie ein normaler externer Akteur behandelt wird und `ci.yml`/`preview-deploy.yml` ganz normal auslöst.
+
+Erwogene Alternative: den GitHub-Actions-Bot als Bypass-Actor in die Ruleset eintragen. Verworfen, weil Rulesets keine Ausnahme pro Workflow erlauben — nur pro Rolle/Team/Integration. Ein Bypass für die Actions-Integration (der Default-`GITHUB_TOKEN` läuft unter dieser Integration) hätte die Regel für **jeden** Workflow im Repo ausgehebelt, nicht nur für `sync-vault.yml`.
 
 ## Tool
 
@@ -66,13 +85,13 @@ vault/.obsidian/
 
 `.github/workflows/sync-vault.yml`
 
-- Trigger: `schedule` (alle 30 Minuten) + `workflow_dispatch` + `repository_dispatch` (Typ `sync-vault`) — Letzteres erlaubt einen On-Demand-Trigger von außen per Webhook: `POST /repos/stefanhoth/stefanhoth.com/dispatches` mit `{"event_type": "sync-vault"}`, authentifiziert mit einem PAT (classic: Scope `repo`; fine-grained: Permission `Contents: write`). Der eingebaute `GITHUB_TOKEN` kann diesen Endpunkt nicht selbst aufrufen — dafür ist ein separates, von Stefan verwaltetes PAT nötig, das nicht Teil dieses Workflows ist.
-- Schritte: `npm ci` → Login → Vault verknüpfen (idempotent, da Runner jedes Mal frisch startet) → Pull-only-Modus setzen → Sync → **`npm run build` als Validierungs-Gate** → Commit & Push, nur wenn der Build durchläuft
-- **Kein `[skip ci]`**: Ein direkter Push mit dem Standard-`GITHUB_TOKEN` löst laut GitHub ohnehin keine Folge-Workflows aus (Rekursionsschutz) — `ci.yml` würde auf diesem Commit gar nicht laufen. Deshalb läuft die Build-Validierung (das eigentliche Sicherheitsnetz für kaputte Frontmatter aus `docs/plans/2026-07-05-obsidian-cms-vault-struktur.md`) **innerhalb** des Sync-Jobs selbst, vor dem Commit — schlägt der Build fehl, wird nichts committet und der Job schlägt sichtbar fehl.
-- **Deploy wird trotzdem getriggert**: Der `GITHUB_TOKEN`-Rekursionsschutz betrifft nur GitHub-Actions-Workflows im selben Repo. Cloudflares GitHub-App bekommt den Push-Webhook auch bei Bot-Pushes zugestellt ([bestätigt in GitHubs Community-Diskussion #25702](https://github.com/orgs/community/discussions/25702)) und deployt den Sync-Commit ganz normal — Content-Update und Deployment sind also **nicht** voneinander getrennt.
-- Credentials aus Repository Secrets (werden nicht im Code gespeichert)
-- `permissions: contents: write`, sonst nichts
-- `checkout` mit `persist-credentials: false`: `npm ci` führt Postinstall-Skripte Dritter aus (u. a. für `better-sqlite3`, eine native Abhängigkeit von `obsidian-headless`); der schreibende `GITHUB_TOKEN` wird erst im letzten Schritt (Commit & Push) explizit in die Remote-URL eingesetzt, damit er während `npm ci` und den Obsidian-CLI-Schritten nicht im Git-Credential-Store liegt
+- Trigger: `schedule` (alle 30 Minuten) + `workflow_dispatch` + `repository_dispatch` (Typ `sync-vault`) — Letzteres erlaubt einen On-Demand-Trigger von außen per Webhook: `POST /repos/stefanhoth/stefanhoth.com/dispatches` mit `{"event_type": "sync-vault"}`, authentifiziert mit einem PAT (classic: Scope `repo`; fine-grained: Permission `Contents: write`). Der eingebaute `GITHUB_TOKEN` kann diesen Endpunkt nicht selbst aufrufen.
+- Schritte: `npm ci` → Login → Vault verknüpfen (idempotent, da Runner jedes Mal frisch startet) → Pull-only-Modus setzen → Sync → **`npm run build` als erste Validierung** → nur bei Änderungen: Branch `sync/vault` von aktuellem `main` neu aufbauen, force-pushen, PR öffnen (falls noch keiner offen ist) und Auto-Merge (Squash) aktivieren
+- Branch-Strategie: fester, wiederverwendeter Branch `sync/vault` statt ein Branch pro Lauf — jeder Lauf baut ihn frisch von `main` aus neu auf (`git checkout -B` + `--force`-Push). Dadurch bleibt ein offener PR immer der vollständige, aktuelle Vault-Stand, auch wenn mehrere 30-Minuten-Zyklen vergehen, bevor die Checks durchlaufen. Nach dem Merge löscht GitHub den Branch automatisch (`deleteBranchOnMerge` ist an), der nächste Lauf legt ihn neu an.
+- Push und PR-Erstellung laufen über `secrets.GH_COMMIT_PAT`, nicht über `GITHUB_TOKEN` — siehe Begründung oben (sonst laufen `ci.yml`/`preview-deploy.yml` gar nicht an, und ein Push auf `main` würde ohnehin an der Ruleset scheitern).
+- `permissions: contents: read` — der Job schreibt nichts mit dem Default-Token, alles Schreibende läuft über das PAT.
+- `checkout` mit `persist-credentials: false`: reines Vorsichtsprinzip, da `npm ci` Postinstall-Skripte Dritter ausführt (u. a. für `better-sqlite3`, eine native Abhängigkeit von `obsidian-headless`).
+- `gh pr list --head sync/vault --state open --json number --jq '.[0].number // empty'` statt `--jq '.[0].number' | grep -q .` — bei leerem Ergebnis-Array liefert `.[0].number` sonst den String `"null"` zurück, der `grep -q .` fälschlich als "PR existiert schon" durchgehen lässt (beim allerersten Lauf würde nie ein PR angelegt). Mit `// empty` bleibt die Variable bei keinem Treffer tatsächlich leer.
 
 ---
 
@@ -85,15 +104,18 @@ vault/.obsidian/
    ```
 2. GitHub Repository Secrets angelegt: `OBSIDIAN_USER`, `OBSIDIAN_PASS`, `OBSIDIAN_VAULT`
 3. Optional: `OBSIDIAN_E2EE`, falls der Vault Ende-zu-Ende-verschlüsselt ist
-4. Ersten Lauf manuell über `workflow_dispatch` anstoßen und Ergebnis prüfen, bevor man sich auf den 30-Minuten-Zeitplan verlässt. Dabei auch verifizieren:
-   - dass der Sync-Commit auf `main` einen `Workers Builds: stefanhoth-com`-Check-Run auslöst (= Deploy läuft)
-   - dass im Cloudflare-Dashboard (**Settings → Builds**) keine [Build Watch Paths](https://developers.cloudflare.com/workers/ci-cd/builds/build-watch-paths/) konfiguriert sind, die `vault/` ausschließen — sonst würde Cloudflare den Build für reine Vault-Commits überspringen und Content-Update und Deployment wären doch getrennt
+4. `GH_COMMIT_PAT` angelegt: ein PAT mit Schreibrechten auf `Contents` und `Pull requests` für dieses Repo (fine-grained, auf dieses eine Repo beschränkt — kein Admin/Owner-Scope nötig, da die Ruleset für normale PRs 0 Approvals verlangt)
+5. Ersten Lauf manuell über `workflow_dispatch` anstoßen und Ergebnis prüfen, bevor man sich auf den 30-Minuten-Zeitplan verlässt. Dabei auch verifizieren:
+   - dass der PR tatsächlich aufgeht und `ci.yml` + `preview-deploy.yml` darauf laufen (nicht nur `workflow_dispatch`/`repository_dispatch` selbst)
+   - dass Auto-Merge sich nach allen 4 grünen Checks + erfolgreichem `preview`-Deployment tatsächlich auslöst
+   - dass der gemergte Commit auf `main` einen `Workers Builds: stefanhoth-com`-Check-Run auslöst (= Cloudflare-Deploy läuft)
 
 ---
 
 ## Offene Punkte
 
 - **Session-Persistenz**: Die Doku von `obsidian-headless` spezifiziert nicht genau, wie/wo Login-Sessions gespeichert werden. Der Workflow loggt sich bei jedem Lauf frisch ein (Runner ist ephemer) — funktioniert, ist aber ggf. langsamer als ein persistenter Client. Sollte sich das nach den ersten Läufen als unzuverlässig erweisen (Rate-Limiting etc.), muss das CLI-Verhalten erneut geprüft werden.
+- **Laufzeit von CI/E2E vs. 30-Minuten-Takt**: Falls `ci.yml` + `preview-deploy.yml` (inkl. E2E gegen die Preview) länger als ein paar Minuten brauchen, könnte der nächste Sync-Lauf schon wieder auf `sync/vault` force-pushen, während der vorherige PR noch auf Checks wartet — GitHubs `strict_required_status_checks_policy` verlangt dann ohnehin einen aktuellen Branch-Stand, sodass sich das über den nächsten Zyklus von selbst auflöst. Noch nicht über mehrere reale Zyklen hinweg beobachtet.
 
 ## Hinweis
 

--- a/docs/plans/2026-07-05-obsidian-sync-headless-pipeline.md
+++ b/docs/plans/2026-07-05-obsidian-sync-headless-pipeline.md
@@ -2,7 +2,7 @@
 
 **Datum:** 2026-07-05
 **Aktualisiert:** 2026-07-08 — Netlify-Annahmen durch den tatsächlichen Cloudflare-Workers-Flow ersetzt, CLI-Kommandos gegen die offizielle `obsidian-headless`-Doku verifiziert. Korrigiert: entgegen einer ersten (falschen) Version dieses Dokuments deployt Cloudflare bei Push auf `main` automatisch in Produktion, über die Cloudflare-GitHub-App ("Cloudflare Workers and Pages", Dashboard-Integration, kein Workflow in diesem Repo) — sichtbar als Check-Run `Workers Builds: stefanhoth-com`. Ein Vault-Sync, der auf `main` landet, geht damit **automatisch live**, sobald Cloudflares eigener Build erfolgreich ist.
-**Zweite Korrektur (nach dem ersten echten Lauf):** Direkter Push auf `main` wird von einer aktiven Repository-Ruleset ("Protect main") abgelehnt — PR Pflicht, 4 grüne Status-Checks (Lint/Build/Test/E2E gegen Preview) und ein erfolgreiches `preview`-Deployment sind Voraussetzung fürs Mergen (0 Approvals nötig). Der Workflow committet daher auf einen festen Branch `sync/vault`, öffnet/aktualisiert dort einen PR und aktiviert Auto-Merge, statt direkt auf `main` zu pushen.
+**Zweite Korrektur (nach dem ersten echten Lauf):** Direkter Push auf `main` wird von einer aktiven Repository-Ruleset ("Protect main") abgelehnt — PR Pflicht, 4 grüne Status-Checks (Lint/Build/Test/E2E gegen Preview) und ein erfolgreiches `preview`-Deployment sind Voraussetzung fürs Mergen (0 Approvals nötig). Der Workflow committet daher auf einen festen Branch `chore/sync-vault`, öffnet/aktualisiert dort einen PR und aktiviert Auto-Merge, statt direkt auf `main` zu pushen.
 **Status:** Umgesetzt (Workflow `sync-vault.yml`) — Repository-Secrets angelegt (`OBSIDIAN_USER`/`PASS`/`VAULT`/`E2EE`, `GH_COMMIT_PAT`).
 
 ---
@@ -18,8 +18,8 @@ Obsidian App (any device)
         ↓  bearbeiten
 Obsidian Sync (Cloud)
         ↓  ob sync (GitHub Actions, alle 30 Min + manuell + Webhook)
-Branch sync/vault  (force-gepusht, nur wenn npm run build durchläuft)
-        ↓  PR main ← sync/vault (per PAT geöffnet, damit Checks überhaupt laufen)
+Branch chore/sync-vault  (force-gepusht, nur wenn npm run build durchläuft)
+        ↓  PR main ← chore/sync-vault (per PAT geöffnet, damit Checks überhaupt laufen)
 ci.yml (Lint/Build/Test) + preview-deploy.yml (Preview-Deployment + E2E)
         ↓  alle 4 Checks grün + erfolgreiches preview-Deployment
 Auto-Merge (squash) → main
@@ -86,12 +86,12 @@ vault/.obsidian/
 `.github/workflows/sync-vault.yml`
 
 - Trigger: `schedule` (alle 30 Minuten) + `workflow_dispatch` + `repository_dispatch` (Typ `sync-vault`) — Letzteres erlaubt einen On-Demand-Trigger von außen per Webhook: `POST /repos/stefanhoth/stefanhoth.com/dispatches` mit `{"event_type": "sync-vault"}`, authentifiziert mit einem PAT (classic: Scope `repo`; fine-grained: Permission `Contents: write`). Der eingebaute `GITHUB_TOKEN` kann diesen Endpunkt nicht selbst aufrufen.
-- Schritte: `npm ci` → Login → Vault verknüpfen (idempotent, da Runner jedes Mal frisch startet) → Pull-only-Modus setzen → Sync → **`npm run build` als erste Validierung** → nur bei Änderungen: Branch `sync/vault` von aktuellem `main` neu aufbauen, force-pushen, PR öffnen (falls noch keiner offen ist) und Auto-Merge (Squash) aktivieren
-- Branch-Strategie: fester, wiederverwendeter Branch `sync/vault` statt ein Branch pro Lauf — jeder Lauf baut ihn frisch von `main` aus neu auf (`git checkout -B` + `--force`-Push). Dadurch bleibt ein offener PR immer der vollständige, aktuelle Vault-Stand, auch wenn mehrere 30-Minuten-Zyklen vergehen, bevor die Checks durchlaufen. Nach dem Merge löscht GitHub den Branch automatisch (`deleteBranchOnMerge` ist an), der nächste Lauf legt ihn neu an.
+- Schritte: `npm ci` → Login → Vault verknüpfen (idempotent, da Runner jedes Mal frisch startet) → Pull-only-Modus setzen → Sync → **`npm run build` als erste Validierung** → nur bei Änderungen: Branch `chore/sync-vault` von aktuellem `main` neu aufbauen, force-pushen, PR öffnen (falls noch keiner offen ist) und Auto-Merge (Squash) aktivieren
+- Branch-Strategie: fester, wiederverwendeter Branch `chore/sync-vault` statt ein Branch pro Lauf — jeder Lauf baut ihn frisch von `main` aus neu auf (`git switch -c` + `--force`-Push). Dadurch bleibt ein offener PR immer der vollständige, aktuelle Vault-Stand, auch wenn mehrere 30-Minuten-Zyklen vergehen, bevor die Checks durchlaufen. Nach dem Merge löscht GitHub den Branch automatisch (`deleteBranchOnMerge` ist an), der nächste Lauf legt ihn neu an.
 - Push und PR-Erstellung laufen über `secrets.GH_COMMIT_PAT`, nicht über `GITHUB_TOKEN` — siehe Begründung oben (sonst laufen `ci.yml`/`preview-deploy.yml` gar nicht an, und ein Push auf `main` würde ohnehin an der Ruleset scheitern).
 - `permissions: contents: read` — der Job schreibt nichts mit dem Default-Token, alles Schreibende läuft über das PAT.
 - `checkout` mit `persist-credentials: false`: reines Vorsichtsprinzip, da `npm ci` Postinstall-Skripte Dritter ausführt (u. a. für `better-sqlite3`, eine native Abhängigkeit von `obsidian-headless`).
-- `gh pr list --head sync/vault --state open --json number --jq '.[0].number // empty'` statt `--jq '.[0].number' | grep -q .` — bei leerem Ergebnis-Array liefert `.[0].number` sonst den String `"null"` zurück, der `grep -q .` fälschlich als "PR existiert schon" durchgehen lässt (beim allerersten Lauf würde nie ein PR angelegt). Mit `// empty` bleibt die Variable bei keinem Treffer tatsächlich leer.
+- `gh pr list --head chore/sync-vault --state open --json number --jq '.[0].number // empty'` statt `--jq '.[0].number' | grep -q .` — bei leerem Ergebnis-Array liefert `.[0].number` sonst den String `"null"` zurück, der `grep -q .` fälschlich als "PR existiert schon" durchgehen lässt (beim allerersten Lauf würde nie ein PR angelegt). Mit `// empty` bleibt die Variable bei keinem Treffer tatsächlich leer.
 
 ---
 
@@ -115,7 +115,7 @@ vault/.obsidian/
 ## Offene Punkte
 
 - **Session-Persistenz**: Die Doku von `obsidian-headless` spezifiziert nicht genau, wie/wo Login-Sessions gespeichert werden. Der Workflow loggt sich bei jedem Lauf frisch ein (Runner ist ephemer) — funktioniert, ist aber ggf. langsamer als ein persistenter Client. Sollte sich das nach den ersten Läufen als unzuverlässig erweisen (Rate-Limiting etc.), muss das CLI-Verhalten erneut geprüft werden.
-- **Laufzeit von CI/E2E vs. 30-Minuten-Takt**: Falls `ci.yml` + `preview-deploy.yml` (inkl. E2E gegen die Preview) länger als ein paar Minuten brauchen, könnte der nächste Sync-Lauf schon wieder auf `sync/vault` force-pushen, während der vorherige PR noch auf Checks wartet — GitHubs `strict_required_status_checks_policy` verlangt dann ohnehin einen aktuellen Branch-Stand, sodass sich das über den nächsten Zyklus von selbst auflöst. Noch nicht über mehrere reale Zyklen hinweg beobachtet.
+- **Laufzeit von CI/E2E vs. 30-Minuten-Takt**: Falls `ci.yml` + `preview-deploy.yml` (inkl. E2E gegen die Preview) länger als ein paar Minuten brauchen, könnte der nächste Sync-Lauf schon wieder auf `chore/sync-vault` force-pushen, während der vorherige PR noch auf Checks wartet — GitHubs `strict_required_status_checks_policy` verlangt dann ohnehin einen aktuellen Branch-Stand, sodass sich das über den nächsten Zyklus von selbst auflöst. Noch nicht über mehrere reale Zyklen hinweg beobachtet.
 
 ## Hinweis
 


### PR DESCRIPTION
## Summary
PR #69 got merged before `sync-vault.yml` ran on its own schedule for the first time — the first real run then failed: `main` is protected by an active repository ruleset ("Protect main") requiring a PR with 4 green status checks (`Lint`/`Build`/`Test`/`E2E against preview`) and a successful `preview` deployment. A direct push (with either `GITHUB_TOKEN` or a PAT) is rejected outright.

- The workflow now pushes to a reused `sync/vault` branch and opens/updates a PR using a PAT (`secrets.GH_COMMIT_PAT`) instead of committing straight to `main`.
- Had to use a PAT rather than `GITHUB_TOKEN` for more than just the ruleset: GitHub doesn't run downstream workflows for events triggered by the default `GITHUB_TOKEN` (not just `push` — `pull_request` too), so `ci.yml`/`preview-deploy.yml` would never have run on a bot-opened PR either.
- Once the PR is open, `gh pr merge --auto --squash` arms auto-merge — it lands as soon as all 4 checks + the preview deployment succeed, no manual click needed.
- `permissions` dropped to `contents: read` — nothing in the job writes with the default token anymore, everything privileged goes through the PAT.
- Fixed a real bug along the way: the "does a PR already exist" check used `jq '.[0].number'`, which returns the literal string `"null"` on an empty array (not empty output) — that would have made the check always believe a PR already existed, so no PR would ever have opened on a clean run.

**Considered and rejected:** adding the GitHub Actions integration as a ruleset bypass actor. Rulesets can only exempt a role/team/integration, not a specific workflow — this would have exempted every workflow's default-token pushes repo-wide, defeating the point of the ruleset for everything, not just this one automation.

## Test plan
- [x] `npm run build`, workflow YAML validated locally
- [ ] Trigger `workflow_dispatch` and confirm: PR opens against `main`, `ci.yml` + `preview-deploy.yml` actually run (not just `workflow_dispatch`), auto-merge fires once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)