### PR TITLE
Serve employee/manager README & projects as file-style .md URLs

### DIFF
--- a/tests/e2e/file-style-urls.spec.ts
+++ b/tests/e2e/file-style-urls.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+// Set (e.g. by the preview-deploy workflow) to run against a deployed Worker
+// instead of the local preview server — see playwright.config.ts.
+const REMOTE = Boolean(process.env.E2E_BASE_URL);
+
+// These vault pages are served under a file-style `.md` URL by the
+// Cloudflare Worker (worker/index.js + wrangler.jsonc's run_worker_first),
+// not by Astro's static build directly — `astro preview` never runs that
+// Worker code, so these only make sense against a real deployment.
+const FILE_STYLE_PAGES = [
+  "/employee-readme.md",
+  "/manager-readme.md",
+  "/projects.md",
+];
+
+for (const path of FILE_STYLE_PAGES) {
+  test(`${path} exists and serves the rendered page`, async ({ page }) => {
+    test.skip(
+      !REMOTE,
+      "The .md alias is served by the Cloudflare Worker, which the local `astro preview` server doesn't run",
+    );
+
+    const response = await page.goto(path);
+    expect(response?.status()).toBe(200);
+    expect(response?.headers()["content-type"]).toContain("text/html");
+    await expect(page.locator("article.prose")).toBeVisible();
+  });
+}

--- a/worker/index.js
+++ b/worker/index.js
@@ -33,12 +33,37 @@ function withSecurityHeaders(response) {
   });
 }
 
+// These vault pages are published as file-style `.md` URLs rather than the
+// folder-style `/<slug>/` URL Astro's static build produces. Requests for
+// the bare or trailing-slash form redirect to the `.md` URL; the `.md`
+// request itself is served by fetching the built page directly, so the
+// visible URL never gets a trailing slash.
+const README_SLUGS = ["employee-readme", "manager-readme"];
+
+async function serveReadmeAlias(url, request, env) {
+  for (const slug of README_SLUGS) {
+    if (url.pathname === `/${slug}.md`) {
+      const assetRequest = new Request(new URL(`/${slug}/`, url), request);
+      return await env.ASSETS.fetch(assetRequest);
+    }
+    if (url.pathname === `/${slug}` || url.pathname === `/${slug}/`) {
+      return Response.redirect(new URL(`/${slug}.md`, url), 301);
+    }
+  }
+  return null;
+}
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
 
     if (request.method === "POST" && url.pathname === "/contact") {
       return withSecurityHeaders(await onRequestPost({ request, env }));
+    }
+
+    const readmeResponse = await serveReadmeAlias(url, request, env);
+    if (readmeResponse) {
+      return withSecurityHeaders(readmeResponse);
     }
 
     return withSecurityHeaders(await env.ASSETS.fetch(request));

--- a/worker/index.js
+++ b/worker/index.js
@@ -38,10 +38,10 @@ function withSecurityHeaders(response) {
 // the bare or trailing-slash form redirect to the `.md` URL; the `.md`
 // request itself is served by fetching the built page directly, so the
 // visible URL never gets a trailing slash.
-const README_SLUGS = ["employee-readme", "manager-readme"];
+const FILE_STYLE_SLUGS = ["employee-readme", "manager-readme", "projects"];
 
-async function serveReadmeAlias(url, request, env) {
-  for (const slug of README_SLUGS) {
+async function serveFileStyleAlias(url, request, env) {
+  for (const slug of FILE_STYLE_SLUGS) {
     if (url.pathname === `/${slug}.md`) {
       const assetRequest = new Request(new URL(`/${slug}/`, url), request);
       return await env.ASSETS.fetch(assetRequest);
@@ -61,9 +61,9 @@ export default {
       return withSecurityHeaders(await onRequestPost({ request, env }));
     }
 
-    const readmeResponse = await serveReadmeAlias(url, request, env);
-    if (readmeResponse) {
-      return withSecurityHeaders(readmeResponse);
+    const fileStyleResponse = await serveFileStyleAlias(url, request, env);
+    if (fileStyleResponse) {
+      return withSecurityHeaders(fileStyleResponse);
     }
 
     return withSecurityHeaders(await env.ASSETS.fetch(request));

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,7 +7,18 @@
   "routes": [{ "pattern": "stefanhoth.com", "custom_domain": true }],
   "assets": {
     "directory": "./dist",
-    "binding": "ASSETS"
+    "binding": "ASSETS",
+    // These paths need the Worker in front of them so it can serve the
+    // .md URL as a file (no trailing-slash redirect) and redirect the
+    // old bare/trailing-slash forms to it. See worker/index.js.
+    "run_worker_first": [
+      "/employee-readme",
+      "/employee-readme/",
+      "/employee-readme.md",
+      "/manager-readme",
+      "/manager-readme/",
+      "/manager-readme.md"
+    ]
   },
   "observability": {
     "logs": {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,7 +17,10 @@
       "/employee-readme.md",
       "/manager-readme",
       "/manager-readme/",
-      "/manager-readme.md"
+      "/manager-readme.md",
+      "/projects",
+      "/projects/",
+      "/projects.md"
     ]
   },
   "observability": {


### PR DESCRIPTION
## Summary
- `/employee-readme` and `/manager-readme` previously redirected to a trailing-slash folder URL (`/employee-readme/`).
- They now redirect (301) to `/employee-readme.md` / `/manager-readme.md`, which serve the same rendered HTML directly as a file-style URL with no further redirect.
- Routed via `wrangler.jsonc`'s `run_worker_first` so the Worker can intercept these specific paths before Cloudflare's asset layer applies its default trailing-slash behavior.

## Test plan
- [x] `wrangler dev` local preview: verified `/employee-readme`, `/employee-readme/`, `/manager-readme`, `/manager-readme/` all 301 to their `.md` counterpart
- [x] Verified `/employee-readme.md` and `/manager-readme.md` return 200 with `Content-Type: text/html; charset=utf-8`
- [x] Screenshot confirms the `.md` URL renders the normal page, not raw markdown
- [x] `npm run build` and Biome lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)