### PR TITLE
Frontmatter-driven publish URLs + vault mirror sync

### DIFF
--- a/.github/workflows/sync-vault.yml
+++ b/.github/workflows/sync-vault.yml
@@ -45,6 +45,17 @@ jobs:
       - name: Add local node_modules/.bin to PATH
         run: echo "$PWD/node_modules/.bin" >> "$GITHUB_PATH"
 
+      # A fresh checkout has no Obsidian Sync state, so a pull never learns
+      # about files that were deleted remotely — they would linger in the
+      # repo forever. Start from an empty directory so the pull produces an
+      # exact mirror of the vault, including deletions and renames. Safe to
+      # do before anything is committed: if the sync fails, the job aborts
+      # and nothing is pushed.
+      - name: Empty the vault directory for a mirror sync
+        run: |
+          rm -rf ./vault
+          mkdir ./vault
+
       - name: Log in to Obsidian Sync
         env:
           OBSIDIAN_EMAIL: ${{ secrets.OBSIDIAN_USER }}

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -122,6 +122,14 @@ The site runs on Cloudflare Workers. A single Worker (`worker/index.js`, configu
 - Global styles in `src/styles/global.css`
 - Custom utilities via Tailwind configuration
 
+### Vault Publishing
+
+Pages come from `vault/`, which `.github/workflows/sync-vault.yml` pulls from Obsidian Sync as an exact mirror (the directory is emptied before each pull, so files deleted or renamed in Obsidian are deleted here too). Because of that, vault content — including frontmatter — must be edited in Obsidian, not in the repo; repo-side edits are overwritten by the next sync.
+
+Frontmatter controls publishing:
+- `publish: true` (plus `title`) — required for a page to be built
+- `permalink: <slug>` or `permalink: <slug>.md` — optional override of the filename-derived slug. With the `.md` suffix the page is published as a file-style URL (`/<slug>.md`); the bare and trailing-slash forms 301-redirect to it. The build writes those slugs to `dist/_file-style-pages.json` (integration in `astro.config.mjs`); the Worker reads that manifest at runtime, with `run_worker_first` in `wrangler.jsonc` routing page requests through it. Wikilinks resolve to the target's permalink.
+
 ### Contact Form
 
 The contact form POSTs to `/contact`, which the Worker routes to `onRequestPost` in `functions/contact.js`. The handler:

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,21 +1,69 @@
-import { readdirSync } from "node:fs";
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { unified } from "@astrojs/markdown-remark";
 import mdx from "@astrojs/mdx";
 import react from "@astrojs/react";
-import { unified } from "@astrojs/markdown-remark";
 import tailwindcss from "@tailwindcss/vite";
-import wikiLink from "remark-wiki-link";
 import { defineConfig } from "astro/config";
+import wikiLink from "remark-wiki-link";
 
-// Vault filenames are the source of truth for slugs (kebab-case, flat
-// directory) — used both to resolve [[Wikilink]] targets to those slugs
-// and to mark links to non-existent pages as "new".
-const vaultPermalinks = readdirSync(new URL("./vault", import.meta.url))
+// Vault files are the source of truth for what gets published and under
+// which URL. The filename provides the default slug; an optional
+// `permalink` frontmatter field overrides it. A permalink ending in `.md`
+// makes the page a "file-style" URL: the Worker serves it at /<slug>.md
+// and redirects the bare/trailing-slash forms there (see worker/index.js).
+//
+// Frontmatter is read with a small regex parser instead of a YAML library
+// because only two scalar fields are needed and the vault is synced from
+// Obsidian, which writes plain `key: value` lines.
+function parseVaultPage(filename) {
+  const raw = readFileSync(
+    new URL(`./vault/${filename}`, import.meta.url),
+    "utf8",
+  );
+  const frontmatter = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/)?.[1] ?? "";
+  return {
+    slug: filename
+      .replace(/\.md$/, "")
+      .trim()
+      .toLowerCase()
+      .replace(/\s+/g, "-"),
+    permalink: frontmatter.match(
+      /^permalink:\s*["']?([^\s"']+)["']?\s*$/m,
+    )?.[1],
+    publish: /^publish:\s*true\s*$/m.test(frontmatter),
+  };
+}
+
+const vaultPages = readdirSync(new URL("./vault", import.meta.url))
   .filter((name) => name.endsWith(".md"))
-  .map((name) => name.replace(/\.md$/, ""));
+  .map(parseVaultPage);
+
+const vaultPagesBySlug = new Map(vaultPages.map((page) => [page.slug, page]));
+
+// Emits the list of file-style page slugs into the build output so the
+// Worker can read it at runtime via the ASSETS binding — the Worker bundle
+// itself is built from a plain checkout (see preview-deploy.yml), so it
+// can't import build-generated modules.
+function fileStyleManifest() {
+  return {
+    name: "file-style-manifest",
+    hooks: {
+      "astro:build:done": ({ dir }) => {
+        const slugs = vaultPages
+          .filter((page) => page.publish && page.permalink?.endsWith(".md"))
+          .map((page) => page.permalink.replace(/\.md$/, ""));
+        writeFileSync(
+          new URL("_file-style-pages.json", dir),
+          JSON.stringify(slugs),
+        );
+      },
+    },
+  };
+}
 
 // https://astro.build/config
 export default defineConfig({
-  integrations: [react(), mdx()],
+  integrations: [react(), mdx(), fileStyleManifest()],
   output: "static",
   site: "https://stefanhoth.com",
   base: "/",
@@ -28,9 +76,15 @@ export default defineConfig({
           {
             aliasDivider: "|",
             pathFormat: "obsidian-short",
-            hrefTemplate: (permalink) => `/${permalink}`,
-            permalinks: vaultPermalinks,
-            pageResolver: (name) => [name.trim().toLowerCase().replace(/\s+/g, "-")],
+            // Resolved wikilinks point at the page's publish URL (its
+            // permalink if set, else the filename slug); unresolved ones
+            // keep the slugified name and get marked "new".
+            hrefTemplate: (slug) =>
+              `/${vaultPagesBySlug.get(slug)?.permalink ?? slug}`,
+            permalinks: vaultPages.map((page) => page.slug),
+            pageResolver: (name) => [
+              name.trim().toLowerCase().replace(/\s+/g, "-"),
+            ],
           },
         ],
       ],

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -18,6 +18,16 @@ const pages = defineCollection({
       title: z.string().optional(),
       description: z.string().optional(),
       publish: z.boolean().default(false),
+      // Overrides the filename-derived slug. With a `.md` suffix the page
+      // is published as a file-style URL (/<slug>.md, served by the Worker);
+      // without it, as a regular folder-style URL (/<slug>/).
+      permalink: z
+        .string()
+        .regex(
+          /^[a-z0-9][a-z0-9-]*(\.md)?$/,
+          "permalink muss ein kebab-case Slug sein, optional mit .md-Endung",
+        )
+        .optional(),
     })
     .superRefine((data, ctx) => {
       if (data.publish && !data.title) {

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -4,7 +4,13 @@ import Layout from "@/layouts/Layout.astro";
 
 export async function getStaticPaths() {
   const pages = await getCollection("pages", ({ data }) => data.publish);
-  return pages.map((page) => ({ params: { slug: page.id }, props: { page } }));
+  // A `permalink` frontmatter field overrides the filename-derived slug.
+  // File-style permalinks (`.md` suffix) still build the folder-style page
+  // here — the Worker serves it under the `.md` URL (see worker/index.js).
+  return pages.map((page) => ({
+    params: { slug: (page.data.permalink ?? page.id).replace(/\.md$/, "") },
+    props: { page },
+  }));
 }
 
 const { page } = Astro.props;

--- a/tests/e2e/file-style-urls.spec.ts
+++ b/tests/e2e/file-style-urls.spec.ts
@@ -4,10 +4,11 @@ import { expect, test } from "@playwright/test";
 // instead of the local preview server — see playwright.config.ts.
 const REMOTE = Boolean(process.env.E2E_BASE_URL);
 
-// These vault pages are served under a file-style `.md` URL by the
-// Cloudflare Worker (worker/index.js + wrangler.jsonc's run_worker_first),
-// not by Astro's static build directly — `astro preview` never runs that
-// Worker code, so these only make sense against a real deployment.
+// Vault pages with a `.md`-suffixed `permalink` frontmatter field are served
+// under a file-style `.md` URL by the Cloudflare Worker (worker/index.js
+// reads the build-generated /_file-style-pages.json manifest), not by
+// Astro's static build directly — `astro preview` never runs that Worker
+// code, so these only make sense against a real deployment.
 const FILE_STYLE_PAGES = [
   "/employee-readme.md",
   "/manager-readme.md",
@@ -26,4 +27,20 @@ for (const path of FILE_STYLE_PAGES) {
     expect(response?.headers()["content-type"]).toContain("text/html");
     await expect(page.locator("article.prose")).toBeVisible();
   });
+
+  const bare = path.replace(/\.md$/, "");
+  for (const legacy of [bare, `${bare}/`]) {
+    test(`${legacy} permanently redirects to ${path}`, async ({ request }) => {
+      test.skip(
+        !REMOTE,
+        "The redirect is served by the Cloudflare Worker, which the local `astro preview` server doesn't run",
+      );
+
+      const response = await request.get(legacy, { maxRedirects: 0 });
+      expect(response.status()).toBe(301);
+      expect(
+        new URL(response.headers().location, "http://unused").pathname,
+      ).toBe(path);
+    });
+  }
 }

--- a/vault/employee-readme.md
+++ b/vault/employee-readme.md
@@ -2,6 +2,7 @@
 title: Employee README
 description: What you can expect from Stefan Hoth as a direct report or colleague.
 publish: true
+permalink: employee-readme.md
 cssclasses:
   - website-page
 created: 2026-06-10

--- a/vault/manager-readme.md
+++ b/vault/manager-readme.md
@@ -2,6 +2,7 @@
 title: Manager README
 description: What you can expect from me as a manager.
 publish: true
+permalink: manager-readme.md
 cssclasses:
   - website-page
 created: 2026-06-10

--- a/vault/projects.md
+++ b/vault/projects.md
@@ -2,6 +2,7 @@
 title: Projects
 description: A few things I've built on the side.
 publish: true
+permalink: projects.md
 ---
 
 # Projects

--- a/worker/index.js
+++ b/worker/index.js
@@ -33,15 +33,31 @@ function withSecurityHeaders(response) {
   });
 }
 
-// These vault pages are published as file-style `.md` URLs rather than the
-// folder-style `/<slug>/` URL Astro's static build produces. Requests for
-// the bare or trailing-slash form redirect to the `.md` URL; the `.md`
-// request itself is served by fetching the built page directly, so the
-// visible URL never gets a trailing slash.
-const FILE_STYLE_SLUGS = ["employee-readme", "manager-readme", "projects"];
+// Vault pages with a `.md`-suffixed `permalink` frontmatter field are
+// published as file-style `.md` URLs rather than the folder-style
+// `/<slug>/` URL Astro's static build produces. Requests for the bare or
+// trailing-slash form redirect to the `.md` URL; the `.md` request itself
+// is served by fetching the built page directly, so the visible URL never
+// gets a trailing slash. The slug list is generated at build time into
+// /_file-style-pages.json (see astro.config.mjs) because this Worker is
+// bundled from a plain checkout without access to build-generated modules.
+let fileStyleSlugsPromise;
+
+function loadFileStyleSlugs(url, env) {
+  fileStyleSlugsPromise ??= env.ASSETS.fetch(
+    new URL("/_file-style-pages.json", url),
+  )
+    .then((response) => (response.ok ? response.json() : []))
+    .catch(() => {
+      // Don't cache a transient failure for the isolate's lifetime.
+      fileStyleSlugsPromise = undefined;
+      return [];
+    });
+  return fileStyleSlugsPromise;
+}
 
 async function serveFileStyleAlias(url, request, env) {
-  for (const slug of FILE_STYLE_SLUGS) {
+  for (const slug of await loadFileStyleSlugs(url, env)) {
     if (url.pathname === `/${slug}.md`) {
       const assetRequest = new Request(new URL(`/${slug}/`, url), request);
       return await env.ASSETS.fetch(assetRequest);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,20 +8,11 @@
   "assets": {
     "directory": "./dist",
     "binding": "ASSETS",
-    // These paths need the Worker in front of them so it can serve the
-    // .md URL as a file (no trailing-slash redirect) and redirect the
-    // old bare/trailing-slash forms to it. See worker/index.js.
-    "run_worker_first": [
-      "/employee-readme",
-      "/employee-readme/",
-      "/employee-readme.md",
-      "/manager-readme",
-      "/manager-readme/",
-      "/manager-readme.md",
-      "/projects",
-      "/projects/",
-      "/projects.md"
-    ]
+    // Page requests go through the Worker so it can serve/redirect the
+    // file-style .md URLs, whose slugs are only known at build time
+    // (frontmatter-driven — see astro.config.mjs and worker/index.js).
+    // Hashed/static assets stay on the asset layer for caching and cost.
+    "run_worker_first": ["/*", "!/_astro/*", "!/img/*"]
   },
   "observability": {
     "logs": {


### PR DESCRIPTION
## Summary

**1. Publish URLs are now controlled from Obsidian via frontmatter** (replaces the hardcoded slug lists from #72):

- New optional `permalink` frontmatter field on vault pages. `permalink: my-page.md` publishes the page as a file-style URL (`/my-page.md`, with 301s from `/my-page` and `/my-page/`); `permalink: my-page` just overrides the filename-derived slug for a regular folder-style URL. No field → filename-derived slug, as before.
- The build writes the file-style slugs to `dist/_file-style-pages.json` (new integration in `astro.config.mjs`); the Worker reads that manifest at runtime via the ASSETS binding. The Worker bundle can't import build output because the deploy job builds it from a plain checkout.
- `run_worker_first` in `wrangler.jsonc` becomes a generic pattern (`/*` minus `/_astro` and `/img`), so new pages need no config change.
- Wikilinks resolve to the target's permalink — cross-page links point straight at the `.md` URL without a redirect hop.
- `employee-readme`, `manager-readme`, and `projects` got their `permalink` set in the repo copies, preserving the URLs from #72.

**2. Vault sync is now a true mirror**: `sync-vault.yml` empties `vault/` before pulling, so files deleted or renamed in Obsidian are deleted from the repo on the next sync. Previously a fresh CI checkout had no sync state and never learned about remote deletions (which is why the stale pre-rename `Employee README.md`/`Manager README.md` copies are still around — the next sync will clean them up, assuming they're gone from the vault).

## ⚠️ Action needed in Obsidian

The `permalink` fields were added to the **repo copies** of the three pages. Since the mirror sync overwrites repo-side edits, please add the same `permalink` lines in Obsidian (`permalink: employee-readme.md`, `permalink: manager-readme.md`, `permalink: projects.md`) — otherwise the next sync PR will drop them and its e2e check will fail (which is the guardrail working as intended).

## Test plan
- [x] `wrangler dev`: all three pages — bare and trailing-slash forms 301 to `.md`; `.md` serves the rendered page (200, `text/html`); home, manifest, and 404 behavior unaffected
- [x] Security headers present on Worker-served pages; `/_astro/*` keeps its immutable cache header from `_headers`
- [x] Wikilink in employee-readme renders as `href="/manager-readme.md"`
- [x] Extended e2e suite (now also asserts the 301s): 9/9 pass against local `wrangler dev`
- [x] `npm run build`, `npm run test` (24/24), Biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)