### PR TITLE
Sidebar page template with build-time h2 table of contents

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -129,6 +129,7 @@ Pages come from `vault/`, which `.github/workflows/sync-vault.yml` pulls from Ob
 Frontmatter controls publishing:
 - `publish: true` (plus `title`) — required for a page to be built
 - `permalink: <slug>` or `permalink: <slug>.md` — optional override of the filename-derived slug. With the `.md` suffix the page is published as a file-style URL (`/<slug>.md`); the bare and trailing-slash forms 301-redirect to it. The build writes those slugs to `dist/_file-style-pages.json` (integration in `astro.config.mjs`); the Worker reads that manifest at runtime, with `run_worker_first` in `wrangler.jsonc` routing page requests through it. Wikilinks resolve to the target's permalink.
+- `template: sidebar` — optional page template (default: `default`). Renders the content with a table-of-contents sidebar linking every h2 as a smooth-scroll anchor. The h2s are extracted at build time by Astro's markdown pipeline (`render()` returns `headings`; `rehypeHeadingIds` stamps the matching `id`s on the headings); `src/pages/[slug].astro` picks the layout, `src/components/TocSidebar.astro` renders the nav. On desktop the sidebar sits sticky right of the content, on mobile above it. Pages without any h2s fall back to the plain template.
 
 ### Contact Form
 

--- a/src/components/TocSidebar.astro
+++ b/src/components/TocSidebar.astro
@@ -1,0 +1,73 @@
+---
+import type { MarkdownHeading } from "astro";
+
+interface Props {
+  headings: MarkdownHeading[];
+}
+
+// The h2s are extracted at build time: Astro's markdown pipeline collects
+// all headings (and stamps matching `id` attributes on them via
+// rehypeHeadingIds), so the sidebar links can point straight at `#slug`.
+const { headings } = Astro.props;
+const items = headings.filter((heading) => heading.depth === 2);
+---
+
+{
+  items.length > 0 && (
+    <nav class="toc" aria-label="On this page">
+      <p class="toc-title">On this page</p>
+      <ul>
+        {items.map((item) => (
+          <li>
+            <a href={`#${item.slug}`}>{item.text}</a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}
+
+<style>
+  .toc {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1rem 1.25rem;
+    box-shadow: var(--shadow);
+  }
+
+  .toc-title {
+    font-size: 0.875rem;
+    color: #666;
+    margin: 0 0 0.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .toc-title {
+      color: #9ca3af;
+    }
+  }
+
+  .toc ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .toc li + li {
+    margin-top: 0.4rem;
+  }
+
+  .toc a {
+    color: inherit;
+    text-decoration: none;
+    font-size: 0.9rem;
+  }
+
+  .toc a:hover {
+    color: var(--accent);
+    text-decoration: underline;
+  }
+</style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -28,6 +28,10 @@ const pages = defineCollection({
           "permalink muss ein kebab-case Slug sein, optional mit .md-Endung",
         )
         .optional(),
+      // Page template. "sidebar" renders the content with a table-of-contents
+      // sidebar linking to every h2 (extracted at build time by Astro's
+      // markdown pipeline, see src/pages/[slug].astro).
+      template: z.enum(["default", "sidebar"]).default("default"),
     })
     .superRefine((data, ctx) => {
       if (data.publish && !data.title) {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,6 +4,7 @@ import "../styles/global.css";
 const {
   title = "Stefan Hoth | Engineering Leader",
   description = "Engineering Leader building high-trust engineering organizations. Currently open to Director or Head of Engineering roles, remote-first.",
+  bodyClass,
 } = Astro.props;
 ---
 
@@ -111,7 +112,7 @@ const {
     <meta name="msapplication-TileImage" content="/img/favs/favicon-144.png" />
     <meta name="msapplication-config" content="/img/favs/browserconfig.xml" />
   </head>
-  <body>
+  <body class={bodyClass}>
     <style is:global>
       :root {
         --bg: #fafafa;

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection, render } from "astro:content";
+import TocSidebar from "@/components/TocSidebar.astro";
 import Layout from "@/layouts/Layout.astro";
 
 export async function getStaticPaths() {
@@ -14,11 +15,77 @@ export async function getStaticPaths() {
 }
 
 const { page } = Astro.props;
-const { Content } = await render(page);
+const { Content, headings } = await render(page);
+
+// `template: sidebar` (frontmatter) renders the content with a sidebar
+// linking to every h2. The headings come out of the markdown build, so a
+// page without any h2s falls back to the plain template.
+const useSidebar =
+  page.data.template === "sidebar" &&
+  headings.some((heading) => heading.depth === 2);
 ---
 
-<Layout title={page.data.title} description={page.data.description}>
-  <article class="prose">
-    <Content />
-  </article>
+<Layout
+  title={page.data.title}
+  description={page.data.description}
+  bodyClass={useSidebar ? "toc-page" : undefined}
+>
+  {
+    useSidebar ? (
+      <div class="toc-layout">
+        <aside class="toc-col">
+          <TocSidebar headings={headings} />
+        </aside>
+        <article class="prose">
+          <Content />
+        </article>
+      </div>
+    ) : (
+      <article class="prose">
+        <Content />
+      </article>
+    )
+  }
 </Layout>
+
+<style>
+  .toc-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 2rem;
+    align-items: start;
+  }
+
+  @media (min-width: 900px) {
+    .toc-layout {
+      grid-template-columns: minmax(0, 600px) 220px;
+      gap: 2.5rem;
+    }
+
+    /* Content left, sidebar right; it stays in view while scrolling. */
+    .toc-col {
+      order: 2;
+      position: sticky;
+      top: 2rem;
+    }
+  }
+</style>
+
+<style is:global>
+  /* Layout.astro caps the body at 600px for the single-column pages;
+     the sidebar template needs room for the extra column. */
+  body.toc-page {
+    max-width: 900px;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    html {
+      scroll-behavior: smooth;
+    }
+  }
+
+  /* Breathing room above a heading after jumping to its anchor. */
+  article.prose :is(h2, h3, h4) {
+    scroll-margin-top: 1.5rem;
+  }
+</style>

--- a/tests/unit/tocSidebar.test.js
+++ b/tests/unit/tocSidebar.test.js
@@ -1,0 +1,44 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import { describe, expect, it } from "vitest";
+import TocSidebar from "../../src/components/TocSidebar.astro";
+
+// Shape of Astro's build-time heading extraction (MarkdownHeading).
+const heading = (depth, slug, text) => ({ depth, slug, text });
+
+const renderSidebar = async (headings) => {
+  const container = await AstroContainer.create();
+  return container.renderToString(TocSidebar, { props: { headings } });
+};
+
+describe("TocSidebar", () => {
+  it("renders an anchor link for every h2, skipping other depths", async () => {
+    const html = await renderSidebar([
+      heading(1, "manager-readme", "Manager README"),
+      heading(2, "my-job", "My job"),
+      heading(3, "a-subsection", "A subsection"),
+      heading(2, "how-i-communicate", "How I communicate"),
+    ]);
+
+    expect(html).toContain('href="#my-job"');
+    expect(html).toContain(">My job</a>");
+    expect(html).toContain('href="#how-i-communicate"');
+    expect(html).toContain(">How I communicate</a>");
+    expect(html).not.toContain("#manager-readme");
+    expect(html).not.toContain("#a-subsection");
+  });
+
+  it("keeps the h2s in document order", async () => {
+    const html = await renderSidebar([
+      heading(2, "first", "First"),
+      heading(2, "second", "Second"),
+    ]);
+
+    expect(html.indexOf("#first")).toBeLessThan(html.indexOf("#second"));
+  });
+
+  it("renders nothing when there are no h2 headings", async () => {
+    const html = await renderSidebar([heading(1, "title-only", "Title only")]);
+
+    expect(html).not.toContain("<nav");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,8 @@
-import { defineConfig } from "vitest/config";
+import { getViteConfig } from "astro/config";
 
-export default defineConfig({
+// getViteConfig wires up Astro's Vite plugins so tests can import and
+// render .astro components (see tests/unit/tocSidebar.test.js).
+export default getViteConfig({
   test: {
     environment: "node",
     include: ["tests/unit/**/*.test.js", "tests/dom/**/*.test.js"],


### PR DESCRIPTION
## What

Vault pages can now opt into a table-of-contents sidebar via frontmatter:

```yaml
template: sidebar
```

Every **h2** on the page becomes a smooth-scroll anchor link in the sidebar.

## How

- **Build-time extraction**: Astro's markdown pipeline already collects all headings during the build (`render()` returns `headings`) and stamps matching `id` attributes on them via `rehypeHeadingIds` — no custom parser needed. `src/pages/[slug].astro` filters them to depth 2 and passes them to the new `TocSidebar.astro` component.
- **Schema**: new `template` field (`default` | `sidebar`, defaults to `default`) in the `pages` collection.
- **Layout**: desktop (≥900px) shows the sidebar sticky to the right of the content; mobile shows it as a card above the content. `Layout.astro` got an optional `bodyClass` prop so the toc pages can widen the 600px body cap.
- **Smooth scroll**: pure CSS (`scroll-behavior: smooth`, gated on `prefers-reduced-motion`) — no JS, so the strict `script-src` CSP stays untouched. `scroll-margin-top` keeps jumped-to headings from sticking to the viewport edge.
- **Fallback**: pages with `template: sidebar` but no h2s render the plain template.

## Tests

- `vitest.config.ts` now uses `getViteConfig` from `astro/config` so tests can import `.astro` components; all 24 existing tests still pass.
- New unit tests render `TocSidebar` via the Astro Container API: one link per h2 (other depths skipped), document order preserved, nothing rendered without h2s.

## Verification

Verified locally in the browser (temporary `template: sidebar` on the manager README, not committed — vault frontmatter is Obsidian-owned): sidebar renders with all 7 h2 links in light/dark mode, desktop + mobile; clicking a link smooth-scrolls to the heading and sets the URL hash; sticky positioning holds while scrolling; no console errors.

Note: no vault page uses the template yet — assign `template: sidebar` in Obsidian to activate it on a page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)