### PR TITLE
Fix low-contrast links in homepage intro text

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -285,6 +285,20 @@ const {
         margin-bottom: 1rem;
       }
 
+      /* Tailwind's preflight resets `a` to `color: inherit`, so links
+         inside the markdown-rendered intro (no .prose wrapper here) need
+         their own color to stand out from the surrounding text. */
+      .about a {
+        color: var(--accent);
+        text-decoration: underline;
+        text-decoration-color: color-mix(in oklab, var(--accent) 40%, transparent);
+        text-underline-offset: 2px;
+      }
+
+      .about a:hover {
+        text-decoration-color: var(--accent);
+      }
+
       .latest-post {
         margin-bottom: 2rem;
         padding: 1rem 1.25rem;


### PR DESCRIPTION
## Summary
- Links in the homepage intro paragraph (e.g. "Check them out here.") had no distinguishing color — Tailwind's preflight resets `a` to `color: inherit`, and the `.about` section (rendered from `vault/home.md`) isn't wrapped in `.prose`, so it never picked up the typography plugin's link color.
- Gave `.about a` the site's existing accent color (`var(--accent)`, `#0d6efd`) plus an underline, with a hover state that darkens the underline to full accent color. Uses the same variable already used for other link affordances (`.link:hover`, nav links), so it matches in both light and dark mode.

## Test plan
- [x] `npm run build` succeeds
- [x] Verified compiled CSS contains `.about a { color: var(--accent); text-decoration: underline; ... }`
- [x] Confirmed the link markup (`<a class="internal" href="/projects.md">Check them out here.</a>`) sits inside `.about` and picks up the new rule


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtAjx8n9BQyQpwD157wztt)_