### PR TITLE
fix(home): restore bullet list styling in About markdown content

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -314,6 +314,23 @@ const ogImageUrl = new URL(ogImage, Astro.site).href;
         margin-bottom: 1rem;
       }
 
+      /* Tailwind's preflight also strips list-style and margin/padding from
+         `ul`/`li`, so the markdown-rendered intro's bullet list needs its
+         own spacing and markers restored (no .prose wrapper here). */
+      .about ul {
+        list-style: disc;
+        margin: 0 0 1rem;
+        padding-left: 1.25rem;
+      }
+
+      .about li {
+        margin-bottom: 0.5rem;
+      }
+
+      .about li:last-child {
+        margin-bottom: 0;
+      }
+
       /* Tailwind's preflight resets `a` to `color: inherit`, so links
          inside the markdown-rendered intro (no .prose wrapper here) need
          their own color to stand out from the surrounding text. */


### PR DESCRIPTION
## Summary

The markdown-rendered intro on the home page (`vault/home.md`) contains a bullet list ("Leadership & Culture", "Scalable Infrastructure", etc.), but it was rendering as plain, unindented paragraphs with no bullets.

Root cause: `About.astro` wraps the rendered markdown in a plain `<div class="about">` (not `.prose`, unlike the vault article pages), and Tailwind's preflight strips `list-style`, `margin`, and `padding` from `ul`/`li` by default. The `.about` block in `Layout.astro` already had manual overrides for `p` spacing and `a` color for this same reason, but was missing the equivalent overrides for lists.

Added `.about ul` / `.about li` rules restoring bullet markers and spacing, consistent with the existing manual patches in that block.

## Test plan

- [x] Ran `npm run dev` and visually confirmed the list now renders with bullets and item spacing in both light and dark color schemes
- [x] `npm run lint` passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01EREmwbL4nY8Ebf6Agw4WWA)_