### PR TITLE
feat(seo): add llms.txt for AI agent discoverability

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,20 @@
+# Stefan Hoth
+
+> Engineering Leader building high-trust engineering organizations. Currently open to Director or Head of Engineering roles, remote-first.
+
+Stefan Hoth has nine years of engineering management experience (Novoda, ResearchGate, SoSafe) and six years building secure, reliable developer execution environments; he applies that same blueprint today to agentic AI workflows. Personal projects lean toward AI agents, job hunting tools, and home automation.
+
+Every page linked below is also served as plain Markdown at the same URL (the links ending in `.md` resolve directly to Markdown, not HTML) — prefer those over the HTML version.
+
+## Pages
+
+- [Home](https://stefanhoth.com/): Bio, focus areas, and current job search status.
+- [How I manage](https://stefanhoth.com/manager-readme.md): What direct reports can expect from Stefan as a manager.
+- [How I show up](https://stefanhoth.com/employee-readme.md): What colleagues and managers can expect from Stefan as a direct report.
+- [Projects](https://stefanhoth.com/projects.md): Personal and open-source projects Stefan has built.
+
+## Optional
+
+- [LinkedIn](https://www.linkedin.com/in/stefanhoth): Professional profile and work history.
+- [Substack: On Engineering Leadership](https://stefanhoth.substack.com): Long-form writing on engineering leadership.
+- [GitHub](https://github.com/stefanhoth): Open source projects and code.

--- a/tests/e2e/llms-txt.spec.ts
+++ b/tests/e2e/llms-txt.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+// llms.txt (https://llmstxt.org/) is a static file served straight out of
+// public/ — no Worker involvement — so it works against both the local
+// `astro preview` server and a real deployment.
+test("/llms.txt is served with the expected llms.txt structure", async ({
+  request,
+}) => {
+  const response = await request.get("/llms.txt");
+  expect(response.status()).toBe(200);
+  expect(response.headers()["content-type"]).toContain("text/plain");
+
+  const body = await response.text();
+  expect(body).toMatch(/^# Stefan Hoth\n/);
+  expect(body).toContain("\n> ");
+  expect(body).toContain("## Pages");
+  expect(body).toContain("(https://stefanhoth.com/manager-readme.md)");
+  expect(body).toContain("(https://stefanhoth.com/employee-readme.md)");
+  expect(body).toContain("(https://stefanhoth.com/projects.md)");
+});


### PR DESCRIPTION
Closes #102.

## Summary

- Adds `public/llms.txt`, served statically at `https://stefanhoth.com/llms.txt`, following the [llmstxt.org](https://llmstxt.org/) spec: H1 title, blockquote summary, a short context paragraph, and an H2 `Pages`/`Optional` link list.
- Points agents at the site's existing `.md`-suffixed page URLs (`/manager-readme.md`, `/employee-readme.md`, `/projects.md`), which the Worker already serves as plain Markdown — no new content pipeline needed.
- Evaluated [agents.md](https://agents.md/) too, per the issue. That spec targets coding agents operating on a *codebase* (build/test/style instructions) — this repo already covers that with `CLAUDE.MD`. It's a different use case from "make the published website legible to agents browsing it", so it's out of scope for this issue; happy to add it separately if useful for other coding tools.

## Test plan

- [x] `npm run lint`
- [x] `npm run build` — confirmed `dist/llms.txt` is emitted with the expected content
- [x] `npm run test` (Vitest unit/dom suite) — all passing
- [x] New Playwright test `tests/e2e/llms-txt.spec.ts` — passing (uses the `request` fixture, no browser launch needed)
- [ ] Other Playwright e2e specs fail locally in this sandbox due to a Chromium binary version mismatch unrelated to this change (confirmed by running the pre-existing `file-style-urls.spec.ts` with the same failure before any of my changes were staged) — expected to pass in CI's properly provisioned environment.


---
_Generated by [Claude Code](https://claude.ai/code/session_0147zhm5C57tW1RW7GQ64ZsZ)_